### PR TITLE
Feat: 모집글 작성 페이지 UI 작업

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import CategoryPage from './pages/CategoryPage';
 import PostListPage from './pages/PostListPage';
+import PostNewPage from './pages/PostNewPage';
 
 export default function App() {
   return (
@@ -17,6 +18,7 @@ export default function App() {
               <Route path="/" element={<HomePage />} />
               <Route path="/category" element={<CategoryPage />} />
               <Route path="/post/:categoryName" element={<PostListPage />} />
+              <Route path="/post/new" element={<PostNewPage />} />
             </Route>
           </Routes>
         </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,11 @@ export default function App() {
         <Router>
           <Routes>
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/post/new" element={<PostNewPage />} />
             <Route element={<Layout />}>
               <Route path="/" element={<HomePage />} />
               <Route path="/category" element={<CategoryPage />} />
               <Route path="/post/:categoryName" element={<PostListPage />} />
-              <Route path="/post/new" element={<PostNewPage />} />
               <Route path="/post/:postId" element={<PostDetailPage />} />
             </Route>
           </Routes>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,57 +1,47 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'default',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    )
-  }
-)
-Button.displayName = "Button"
+    const Comp = asChild ? Slot : 'button';
+    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+  },
+);
+Button.displayName = 'Button';
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -1,13 +1,16 @@
 import { FaLongArrowAltLeft } from 'react-icons/fa';
 import { RiArrowDownSLine } from 'react-icons/ri';
 import { FaPlus } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
 
 export default function PostNewPage() {
   return (
     <section className="mt-24 pb-20">
       <div className="flex items-center justify-between border-b border-black h-[60px]">
         <div className="flex items-center gap-2.5">
-          <FaLongArrowAltLeft className="w-5 h-5" />
+          <Link to="/">
+            <FaLongArrowAltLeft className="w-5 h-5" />
+          </Link>
           <h3 className="font-semibold">모집글 쓰기</h3>
         </div>
         <button type="submit" className="py-0.5 px-3 bg-[#4696D3] rounded-md text-white">

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -1,5 +1,6 @@
 import { FaLongArrowAltLeft } from 'react-icons/fa';
 import { RiArrowDownSLine } from 'react-icons/ri';
+import { RiArrowUpSLine } from 'react-icons/ri';
 import { FaPlus } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import { CATEGORIES } from '@/lib/data';
@@ -45,9 +46,15 @@ export default function PostNewPage() {
           <button type="button" onClick={handleButtonClick} className="font-semibold w-11/12 text-left">
             {selectedCategory || '카테고리'}
           </button>
-          <button type="button">
-            <RiArrowDownSLine className="w-6 h-6" />
-          </button>
+          {toggle ? (
+            <button type="button">
+              <RiArrowUpSLine className="w-6 h-6" />
+            </button>
+          ) : (
+            <button type="button">
+              <RiArrowDownSLine className="w-6 h-6" />
+            </button>
+          )}
           {toggle && (
             <ul className="w-full absolute left-0 top-[57px] bg-white border-x rounded-b-2xl border-b pb-2.5">
               {CATEGORIES.map(category => (

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -1,3 +1,61 @@
+import { FaLongArrowAltLeft } from 'react-icons/fa';
+import { RiArrowDownSLine } from 'react-icons/ri';
+import { FaPlus } from 'react-icons/fa';
+
 export default function PostNewPage() {
-  return <div>모집글 작성 페이지</div>;
+  return (
+    <section className="mt-24 pb-20">
+      <div className="flex items-center justify-between border-b border-black h-[60px]">
+        <div className="flex items-center gap-2.5">
+          <FaLongArrowAltLeft className="w-5 h-5" />
+          <h3 className="font-semibold">모집글 쓰기</h3>
+        </div>
+        <button type="submit" className="py-0.5 px-3 bg-[#4696D3] rounded-md text-white">
+          등록
+        </button>
+      </div>
+      <div>
+        <div className="flex items-center justify-between py-4 border-b">
+          <button type="button" className="font-semibold w-11/12 text-left">
+            카테고리
+          </button>
+          <button type="button">
+            <RiArrowDownSLine className="w-6 h-6" />
+          </button>
+        </div>
+        <form>
+          <input type="text" placeholder="게시글 제목" className="w-full outline-none py-4 border-b" />
+          <div className="flex items-center justify-between py-4 border-b text-black">
+            <input type="text" placeholder="상품 이름" className="outline-none" />
+            <button type="button">
+              <FaPlus className="w-3 h-3 mr-1" />
+            </button>
+          </div>
+          <div className="flex items-center justify-between py-4 border-b text-black">
+            <input type="text" placeholder="상품 링크" className="outline-none" />
+            <button type="button">
+              <FaPlus className="w-3 h-3 mr-1" />
+            </button>
+          </div>
+          <input type="text" placeholder="희망 거래 장소" className="w-full outline-none py-4 border-b" />
+          <input type="text" placeholder="희망 모집 인원" className="w-full outline-none py-4 border-b" />
+          <input type="text" placeholder="원래 가격" className="w-full outline-none py-4 border-b" />
+          <input type="text" placeholder="인당 가격" className="w-full outline-none py-4 border-b" />
+          <input type="text" placeholder="마감일" className="w-full outline-none py-4 border-b" />
+          <textarea
+            cols={30}
+            rows={10}
+            placeholder="상세 정보"
+            className="w-full outline-none py-4 border-b resize-none"
+          ></textarea>
+        </form>
+        <div className="flex gap-8 w-full py-4 border-b">
+          <p className="text-[#C4C4C4] font-semibold">사진</p>
+          <button type="button" className="w-[53px] h-[53px] border bg-gray-300">
+            +
+          </button>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -31,7 +31,7 @@ export default function PostNewPage() {
     <section className="px-5">
       <div className="flex items-center justify-between border-b border-black h-[60px]">
         <div className="flex items-center gap-2.5">
-          <Link to="/">
+          <Link to="/post/:categoryName">
             <FaLongArrowAltLeft className="w-5 h-5" />
           </Link>
           <h3 className="font-semibold">모집글 쓰기</h3>

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -2,6 +2,7 @@ import { FaLongArrowAltLeft } from 'react-icons/fa';
 import { RiArrowDownSLine } from 'react-icons/ri';
 import { FaPlus } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
+import { CATEGORIES } from '@/lib/data';
 
 export default function PostNewPage() {
   return (
@@ -18,13 +19,20 @@ export default function PostNewPage() {
         </button>
       </div>
       <div>
-        <div className="flex items-center justify-between py-4 border-b">
+        <div className="flex items-center justify-between py-4 border-b relative">
           <button type="button" className="font-semibold w-11/12 text-left">
             카테고리
           </button>
           <button type="button">
             <RiArrowDownSLine className="w-6 h-6" />
           </button>
+          <ul className="w-full absolute left-0 top-[57px] bg-white border-x rounded-b-2xl border-b pb-2.5">
+            {CATEGORIES.map(category => (
+              <li key={category.type} className="w-full py-4 px-2.5 hover:bg-slate-100">
+                <button className="w-full text-left">{category.name}</button>
+              </li>
+            ))}
+          </ul>
         </div>
         <form>
           <input type="text" placeholder="게시글 제목" className="w-full outline-none py-4 border-b" />

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -1,0 +1,3 @@
+export default function PostNewPage() {
+  return <div>모집글 작성 페이지</div>;
+}

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -6,7 +6,7 @@ import { CATEGORIES } from '@/lib/data';
 
 export default function PostNewPage() {
   return (
-    <section className="mt-24 pb-20">
+    <section className="pb-20">
       <div className="flex items-center justify-between border-b border-black h-[60px]">
         <div className="flex items-center gap-2.5">
           <Link to="/">

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -3,10 +3,32 @@ import { RiArrowDownSLine } from 'react-icons/ri';
 import { FaPlus } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import { CATEGORIES } from '@/lib/data';
+import React, { useState } from 'react';
 
 export default function PostNewPage() {
+  // 카테고리 오픈
+  const [openCategory, setOpenCategory] = useState(false);
+
+  // 카테고리 선택
+  const [selectedCategory, setSelectedCategory] = useState('');
+
+  // 카테고리 리스트 토글
+  const [toggle, setToggle] = useState<boolean>(false);
+
+  const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setOpenCategory(!openCategory);
+    setToggle(true);
+  };
+
+  const handleCategoryClick = (category: string) => {
+    setOpenCategory(false);
+    setSelectedCategory(category);
+    setToggle(false);
+  };
+
   return (
-    <section className="pb-20">
+    <section className="mt-24 pb-20">
       <div className="flex items-center justify-between border-b border-black h-[60px]">
         <div className="flex items-center gap-2.5">
           <Link to="/">
@@ -20,19 +42,25 @@ export default function PostNewPage() {
       </div>
       <div>
         <div className="flex items-center justify-between py-4 border-b relative">
-          <button type="button" className="font-semibold w-11/12 text-left">
-            카테고리
+          <button type="button" onClick={handleButtonClick} className="font-semibold w-11/12 text-left">
+            {selectedCategory || '카테고리'}
           </button>
           <button type="button">
             <RiArrowDownSLine className="w-6 h-6" />
           </button>
-          <ul className="w-full absolute left-0 top-[57px] bg-white border-x rounded-b-2xl border-b pb-2.5">
-            {CATEGORIES.map(category => (
-              <li key={category.type} className="w-full py-4 px-2.5 hover:bg-slate-100">
-                <button className="w-full text-left">{category.name}</button>
-              </li>
-            ))}
-          </ul>
+          {toggle && (
+            <ul className="w-full absolute left-0 top-[57px] bg-white border-x rounded-b-2xl border-b pb-2.5">
+              {CATEGORIES.map(category => (
+                <li
+                  key={category.type}
+                  onClick={() => handleCategoryClick(category.name)}
+                  className="w-full py-4 px-2.5 hover:bg-slate-100"
+                >
+                  <button className="w-full text-left">{category.name}</button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
         <form>
           <input type="text" placeholder="게시글 제목" className="w-full outline-none py-4 border-b" />

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -28,7 +28,7 @@ export default function PostNewPage() {
   };
 
   return (
-    <section className="mt-24 pb-20">
+    <section className="px-5">
       <div className="flex items-center justify-between border-b border-black h-[60px]">
         <div className="flex items-center gap-2.5">
           <Link to="/">
@@ -36,7 +36,7 @@ export default function PostNewPage() {
           </Link>
           <h3 className="font-semibold">모집글 쓰기</h3>
         </div>
-        <button type="submit" className="py-0.5 px-3 bg-[#4696D3] rounded-md text-white">
+        <button type="submit" className="py-0.5 px-3 bg-primary rounded-md text-white">
           등록
         </button>
       </div>


### PR DESCRIPTION
## 연관 이슈

#17 

### 요약

- 모집글 작성 페이지

### 타입

- [x] feat : 새로운 기능 추가, 기존의 기능을 요구 사항에 맞추어 수정
- [ ] fix : 기능에 대한 버그, 오류 수정
- [ ] add : feat 이외의 부수적인 코드 추가, 라이브러리 추가
- [ ] build : 빌드 관련 수정
- [ ] chore : 프로덕션 코드 외 빌드 부분 혹은 패키지 매니저 수정사항 (ex. .gitignore)
- [x] design : css 및 레이아웃 작업
- [ ] docs : 문서,주석 수정
- [ ] style : 코드 스타일, 포맷팅에 대한 수정
- [x] refactor : 기능의 변화가 아닌 코드 리팩터링 (ex. 변수 이름 변경)
- [ ] test : 테스트 코드 추가/수정

### 작업 내용

- 모집글 작성 페이지 UI
- 카테고리 리스트 UI
- 카테고리 선택 기능 (PR 승인 검토가 아직 안되서 새로운 PR을 생성하지 못해 카테고리 선택 기능을 이곳에 커밋하였습니다.)

### 스크린샷(선택)
- 기본 화면
![d90d49a1-db47-4706-bd80-266cbd523e05](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/53bd6938-af24-482b-9f68-9fe70b84e3db)

- 카테고리 리스트 화면
![카테고리 리스트](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/03e13f09-7bdc-4d5f-930e-3830738604db)


### 논의하고 싶은 부분

> 현재 와이어프레임에는 게시글 제목이 없어서 추가하였습니다.
UI 관련 수정하고 싶으신 부분 있으시면 코멘트 남겨주세요!

> 뒤로가기 버튼 클릭시 우선은 메인 페이지로 이동하도록 해두었습니다.
해당 부분에서 메인페이지로 이동시킬지, 아니면 게시글 목록으로 이동시킬지 논의해보고싶습니다.
