### PR TITLE
Feat: 참여내역 페이지 UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
             <Routes>
               <Route path="/login" element={<LoginPage />} />
               <Route path="/post/new" element={<PostNewPage />} />
+              <Route path="/my/edit/profile" element={<EditProfile />} />
               <Route element={<Layout />}>
                 <Route path="/" element={<HomePage />} />
                 <Route path="/posts/:selectedCategory" element={<PostListPage />} />
@@ -30,7 +31,6 @@ export default function App() {
                 <Route path="/my" element={<MyPage />} />
                 <Route path="/my/bookmark" element={<BookMarkPage />} />
                 <Route path="/my/profile" element={<ProfilePage />} />
-                <Route path="/my/edit/profile" element={<EditProfile />} />
               </Route>
             </Routes>
           </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import MyPage from './pages/MyPage';
 import BookMarkPage from './pages/BookMarkPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ProfilePage from './pages/MyProfilePage';
+import EditProfile from './components/profilePage/EditProfile';
 
 const queryClient = new QueryClient();
 
@@ -29,6 +30,7 @@ export default function App() {
                 <Route path="/my" element={<MyPage />} />
                 <Route path="/my/bookmark" element={<BookMarkPage />} />
                 <Route path="/my/profile" element={<ProfilePage />} />
+                <Route path="/my/edit/profile" element={<EditProfile />} />
               </Route>
             </Routes>
           </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import PostDetailPage from './pages/PostDetailPage';
 import MyPage from './pages/MyPage';
 import BookMarkPage from './pages/BookMarkPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ProfilePage from './pages/MyProfilePage';
 
 const queryClient = new QueryClient();
 
@@ -27,6 +28,7 @@ export default function App() {
                 <Route path="/post/:postId" element={<PostDetailPage />} />
                 <Route path="/my" element={<MyPage />} />
                 <Route path="/my/bookmark" element={<BookMarkPage />} />
+                <Route path="/my/profile" element={<ProfilePage />} />
               </Route>
             </Routes>
           </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ProfilePage from './pages/MyProfilePage';
 import EditProfile from './components/profilePage/EditProfile';
 import HistoryPage from './pages/HistoryPage';
+import HistoryDetailPage from './components/historyPage/HistoryDetailPage';
 
 const queryClient = new QueryClient();
 
@@ -33,6 +34,7 @@ export default function App() {
                 <Route path="/my/bookmark" element={<BookMarkPage />} />
                 <Route path="/my/profile" element={<ProfilePage />} />
                 <Route path="/my/history" element={<HistoryPage />} />
+                <Route path="/my/history/:postId" element={<HistoryDetailPage />} />
               </Route>
             </Routes>
           </Router>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import BookMarkPage from './pages/BookMarkPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ProfilePage from './pages/MyProfilePage';
 import EditProfile from './components/profilePage/EditProfile';
+import HistoryPage from './pages/HistoryPage';
 
 const queryClient = new QueryClient();
 
@@ -31,6 +32,7 @@ export default function App() {
                 <Route path="/my" element={<MyPage />} />
                 <Route path="/my/bookmark" element={<BookMarkPage />} />
                 <Route path="/my/profile" element={<ProfilePage />} />
+                <Route path="/my/history" element={<HistoryPage />} />
               </Route>
             </Routes>
           </Router>

--- a/src/components/historyPage/HistoryDetailPage.tsx
+++ b/src/components/historyPage/HistoryDetailPage.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '../ui/button';
 import KakaoMapScriptLoader from '@/map/KakaoMapScriptLoader';
 import { ClockIcon } from '@radix-ui/react-icons';
+import { Link } from 'react-router-dom';
 
 export default function HistoryDetailPage() {
   return (
@@ -30,12 +31,12 @@ export default function HistoryDetailPage() {
           <div className="ml-6 my-6">
             <section className="grid grid-cols-1 gap-5 ">
               <li className="flex gap-5">
-                <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품명</div>
-                <div className="h-fit">휴지</div>
+                <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께 산 상품</div>
+                <div className="h-fit">크리오덴티메이트 칫솔</div>
               </li>
               <li className="flex gap-5">
                 <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품링크</div>
-                <div className="h-fit">http</div>
+                <div className="h-fit">https://zero-base.co.kr/</div>
               </li>
               <li className="flex items-center gap-5">
                 <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께한 참여자</div>
@@ -64,9 +65,14 @@ export default function HistoryDetailPage() {
           </div>
         </ul>
       </div>
-      <Button className="w-[150px] mt-4 mb-20" variant={'outline'}>
-        매너점수 평가하기
-      </Button>
+      <div className="flex gap-2">
+        <Button className="w-[150px] mt-4 mb-20" variant={'outline'}>
+          매너점수 평가하기
+        </Button>
+        <Button className="ml-auto mt-4 mb-20" variant={'outline'}>
+          <Link to="/my/history">목록으로</Link>
+        </Button>
+      </div>
     </section>
   );
 }

--- a/src/components/historyPage/HistoryDetailPage.tsx
+++ b/src/components/historyPage/HistoryDetailPage.tsx
@@ -1,3 +1,72 @@
+import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '../ui/button';
+import KakaoMapScriptLoader from '@/map/KakaoMapScriptLoader';
+import { ClockIcon } from '@radix-ui/react-icons';
+
 export default function HistoryDetailPage() {
-  return <div>참여내역 상세</div>;
+  return (
+    <section className="flex flex-col items-center gap-2 border-b border-slate-200 py-6">
+      <h1 className="font-bold text-3xl">칫솔과 휴지를 함께 사실 분을 모집합니다!</h1>
+      <div className="flex justify-center">
+        <Carousel className="w-full max-w-sm my-10">
+          <CarouselContent>
+            <CarouselItem>
+              <div className="p-1">
+                <Card>
+                  <CardContent className="flex aspect-square items-center justify-center p-6">
+                    <div className="w-24 h-48 justify-center bg-no-repeat bg-cover bg-center" />
+                  </CardContent>
+                </Card>
+              </div>
+            </CarouselItem>
+          </CarouselContent>
+          <CarouselPrevious />
+          <CarouselNext />
+        </Carousel>
+      </div>
+      <div>
+        <ul className="flex justify-center border-slate-200 py-6 gap-20">
+          <div className="ml-6 my-6">
+            <section className="grid grid-cols-1 gap-5 ">
+              <li className="flex gap-5">
+                <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품명</div>
+                <div className="h-fit">휴지</div>
+              </li>
+              <li className="flex gap-5">
+                <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품링크</div>
+                <div className="h-fit">http</div>
+              </li>
+              <li className="flex items-center gap-5">
+                <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께한 참여자</div>
+                <div className="h-fit">유저 1</div>
+                <div className="h-fit">유저 2</div>
+                <div className="h-fit">유저 3</div>
+                <Button variant={'outline'} size={'lg'}>
+                  채팅
+                </Button>
+              </li>
+              <li className="flex gap-5">
+                <div className="text-dark-gray font-bold w-24 flex-shrink-0">마감일</div>
+                <div className="flex justify-center items-center gap-1 h-fit">
+                  <ClockIcon />
+                  2024-04-18
+                </div>
+              </li>
+              <li className="flex gap-5">
+                <div className="text-dark-gray font-bold w-24 flex-shrink-0">만남장소</div>
+                <div className="h-fit">서울특별시 강남구 테헤란로 427</div>
+              </li>
+            </section>
+            <KakaoMapScriptLoader>
+              <div className="w-full h-[100px] border mt-8">지도 영역</div>
+            </KakaoMapScriptLoader>
+          </div>
+        </ul>
+      </div>
+      <Button className="w-[150px] mt-4 mb-20" variant={'outline'}>
+        매너점수 평가하기
+      </Button>
+    </section>
+  );
 }

--- a/src/components/historyPage/HistoryDetailPage.tsx
+++ b/src/components/historyPage/HistoryDetailPage.tsx
@@ -1,0 +1,3 @@
+export default function HistoryDetailPage() {
+  return <div>참여내역 상세</div>;
+}

--- a/src/components/historyPage/HistoryDetailPage.tsx
+++ b/src/components/historyPage/HistoryDetailPage.tsx
@@ -2,7 +2,6 @@ import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '../ui/button';
 import KakaoMapScriptLoader from '@/map/KakaoMapScriptLoader';
-import { ClockIcon } from '@radix-ui/react-icons';
 import { Link } from 'react-router-dom';
 
 export default function HistoryDetailPage() {
@@ -34,10 +33,6 @@ export default function HistoryDetailPage() {
                 <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께 산 상품</div>
                 <div className="h-fit">크리오덴티메이트 칫솔</div>
               </li>
-              <li className="flex gap-5">
-                <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품링크</div>
-                <div className="h-fit">https://zero-base.co.kr/</div>
-              </li>
               <li className="flex items-center gap-5">
                 <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께한 참여자</div>
                 <div className="h-fit">유저 1</div>
@@ -46,13 +41,6 @@ export default function HistoryDetailPage() {
                 <Button variant={'outline'} size={'lg'}>
                   채팅
                 </Button>
-              </li>
-              <li className="flex gap-5">
-                <div className="text-dark-gray font-bold w-24 flex-shrink-0">마감일</div>
-                <div className="flex justify-center items-center gap-1 h-fit">
-                  <ClockIcon />
-                  2024-04-18
-                </div>
               </li>
               <li className="flex gap-5">
                 <div className="text-dark-gray font-bold w-24 flex-shrink-0">만남장소</div>

--- a/src/components/historyPage/HistoryList.tsx
+++ b/src/components/historyPage/HistoryList.tsx
@@ -8,7 +8,7 @@ export default function HistoryList() {
         className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
       >
         <div className="flex items-center gap-x-2">
-          <h2 className="font-bold text-xl">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
+          <h2 className="font-bold text-lg">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
         </div>
         <div className="flex">
           <ul className="flex flex-col gap-2 text-sm opacity-50">
@@ -35,7 +35,7 @@ export default function HistoryList() {
         className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
       >
         <div className="flex items-center gap-x-2">
-          <h2 className="font-bold text-xl">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
+          <h2 className="font-bold text-lg">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
         </div>
         <div className="flex">
           <ul className="flex flex-col gap-2 text-sm opacity-50">

--- a/src/components/historyPage/HistoryList.tsx
+++ b/src/components/historyPage/HistoryList.tsx
@@ -8,7 +8,7 @@ export default function HistoryList() {
         className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
       >
         <div className="flex items-center gap-x-2">
-          <h2 className="font-bold text-base">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
+          <h2 className="font-bold text-xl">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
         </div>
         <div className="flex">
           <ul className="flex flex-col gap-2 text-sm opacity-50">
@@ -35,7 +35,7 @@ export default function HistoryList() {
         className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
       >
         <div className="flex items-center gap-x-2">
-          <h2 className="font-bold text-base">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
+          <h2 className="font-bold text-xl">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
         </div>
         <div className="flex">
           <ul className="flex flex-col gap-2 text-sm opacity-50">

--- a/src/components/historyPage/HistoryList.tsx
+++ b/src/components/historyPage/HistoryList.tsx
@@ -1,34 +1,197 @@
+// import { Link } from 'react-router-dom';
+// import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
+// import { Card, CardContent } from '@/components/ui/card';
+
 import { Link } from 'react-router-dom';
+
+// export default function HistoryList() {
+//   return (
+//     <div className="w-full">
+//       <div className="flex w-full justify-center flex-col border-b border-slate-200 py-6">
+//         <div className="flex justify-center items-center gap-14">
+//           <div className="flex justify-center">
+//             <Carousel className="w-full max-w-sm">
+//               <CarouselContent>
+//                 <CarouselItem>
+//                   <div className="p-1">
+//                     <Card>
+//                       <CardContent className="flex aspect-square items-center justify-center p-6">
+//                         <div className="w-24 h-48 justify-center bg-no-repeat bg-cover bg-center" />
+//                       </CardContent>
+//                     </Card>
+//                   </div>
+//                 </CarouselItem>
+//               </CarouselContent>
+//               <CarouselPrevious className="bg-slate-200" />
+//               <CarouselNext className="bg-slate-200" />
+//             </Carousel>
+//           </div>
+//           <ul className="flex justify-center border-slate-200 gap-20">
+//             <div className="ml-6 my-6">
+//               <section className="grid grid-cols-1 gap-5 ">
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">게시글 제목</div>
+//                   <div className="h-fit">휴지를 함께 사실 분을 모집합니다!</div>
+//                 </li>
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께 산 상품</div>
+//                   <div className="flex flex-col gap-1">
+//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">크리오덴티메이트 칫솔</div>
+//                   </div>
+//                 </li>
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품링크</div>
+//                   <div className="flex flex-col gap-1">
+//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">https://zero-base.co.kr/</div>
+//                   </div>
+//                 </li>
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께한 참여자</div>
+//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 1</div>
+//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 2</div>
+//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 3</div>
+//                 </li>
+//               </section>
+//             </div>
+//           </ul>
+//         </div>
+//         <div className="flex items-end justify-center flex-col mt-8">
+//           <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
+//             보기
+//           </Link>
+//         </div>
+//       </div>
+//       <div className="flex justify-center w-full flex-col border-b border-slate-200 py-6">
+//         <div className="flex justify-center items-center gap-14">
+//           <div className="flex justify-center">
+//             <Carousel className="w-full max-w-sm">
+//               <CarouselContent>
+//                 <CarouselItem>
+//                   <div className="p-1">
+//                     <Card>
+//                       <CardContent className="flex aspect-square items-center justify-center p-6">
+//                         <div className="w-24 h-48 justify-center bg-no-repeat bg-cover bg-center" />
+//                       </CardContent>
+//                     </Card>
+//                   </div>
+//                 </CarouselItem>
+//               </CarouselContent>
+//               <CarouselPrevious />
+//               <CarouselNext />
+//             </Carousel>
+//           </div>
+//           <ul className="flex justify-center border-slate-200 gap-20">
+//             <div className="ml-6 my-6">
+//               <section className="grid grid-cols-1 gap-5 ">
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">게시글 제목</div>
+//                   <div className="h-fit">칫솔과 휴지를 함께 사실 분을 모집합니다!</div>
+//                 </li>
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께 산 상품</div>
+//                   <div className="flex flex-col gap-1">
+//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">크리오덴티메이트 칫솔</div>
+//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">크리오덴티메이트 칫솔</div>
+//                   </div>
+//                 </li>
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품링크</div>
+//                   <div className="flex flex-col gap-1">
+//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">https://zero-base.co.kr/</div>
+//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">https://zero-base.co.kr/</div>
+//                   </div>
+//                 </li>
+//                 <li className="flex gap-5">
+//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께한 참여자</div>
+//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 1</div>
+//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 2</div>
+//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 3</div>
+//                 </li>
+//               </section>
+//             </div>
+//           </ul>
+//         </div>
+//         <div className="flex items-end justify-center flex-col mt-8">
+//           <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
+//             보기
+//           </Link>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
 
 export default function HistoryList() {
   return (
-    <div className="flex w-full flex-col mt-10">
-      <div className="flex justify-center gap-7 mt-10">
-        <div className="w-36 h-36 bg-gray-500 "></div>
-        <div>
-          <div className="flex items-center justify-between gap-10 mb-3">
-            <p className="py-0.5 px-3 border rounded-md text-lg">제품명</p>
-            <p className="w-[150px] text-left">휴지</p>
-          </div>
-          <div className="flex items-center justify-between gap-10 mb-3">
-            <p className="py-0.5 px-3 border rounded-md text-lg">제품 링크</p>
-            <p className="w-[150px] text-left">https</p>
-          </div>
-          <div className="flex items-center justify-between gap-10 mb-3">
-            <p className="py-0.5 px-3 border rounded-md text-lg">상태</p>
-            <p className="w-[150px] text-left">모집중</p>
-          </div>
-          <div className="flex items-center justify-between gap-10 mb-3">
-            <p className="py-0.5 px-3 border rounded-md text-lg">함께한 참여자</p>
-            <p className="w-[150px] text-left">유저 100</p>
-          </div>
+    <div className="w-full mt-6">
+      <Link
+        to="/my/history/:postId"
+        className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
+      >
+        <div className="flex items-center gap-x-2">
+          <h2 className="font-bold">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
         </div>
-      </div>
-      <div className="flex items-end justify-center flex-col mt-8">
-        <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
-          보기
-        </Link>
-      </div>
+        <div className="flex">
+          <ul className="flex flex-col gap-2 text-sm opacity-50">
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">함께 산 상품</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
+            </li>
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">제품링크</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">https://zero-base.co.kr/</div>
+            </li>
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">모집상태</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">모집중</div>
+            </li>
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">함께한 참여자</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 1</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 2</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 3</div>
+            </li>
+          </ul>
+        </div>
+        <div className="flex items-end justify-center flex-col">
+          <button className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">보기</button>
+        </div>
+      </Link>
+      <Link
+        to="/my/history/:postId"
+        className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
+      >
+        <div className="flex items-center gap-x-2">
+          <h2 className="font-bold">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
+        </div>
+        <div className="flex">
+          <ul className="flex flex-col gap-2 text-sm opacity-50">
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">함께 산 상품</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
+            </li>
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">제품링크</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">https://zero-base.co.kr/</div>
+            </li>
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">모집상태</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">모집중</div>
+            </li>
+            <li className="flex gap-2 py-[2px]">
+              <div className="font-bold flex-shrink-0 ">함께한 참여자</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 1</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 2</div>
+              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 3</div>
+            </li>
+          </ul>
+        </div>
+        <div className="flex items-end justify-center flex-col">
+          <button className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">보기</button>
+        </div>
+      </Link>
     </div>
   );
 }

--- a/src/components/historyPage/HistoryList.tsx
+++ b/src/components/historyPage/HistoryList.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router-dom';
+
+export default function HistoryList() {
+  return (
+    <div className="flex w-full flex-col mt-10">
+      <div className="flex justify-center gap-7 mt-10">
+        <div className="w-36 h-36 bg-gray-500 "></div>
+        <div>
+          <div className="flex items-center justify-between gap-10 mb-3">
+            <p className="py-0.5 px-3 border rounded-md text-lg">제품명</p>
+            <p className="w-[150px] text-left">휴지</p>
+          </div>
+          <div className="flex items-center justify-between gap-10 mb-3">
+            <p className="py-0.5 px-3 border rounded-md text-lg">제품 링크</p>
+            <p className="w-[150px] text-left">https</p>
+          </div>
+          <div className="flex items-center justify-between gap-10 mb-3">
+            <p className="py-0.5 px-3 border rounded-md text-lg">상태</p>
+            <p className="w-[150px] text-left">모집중</p>
+          </div>
+          <div className="flex items-center justify-between gap-10 mb-3">
+            <p className="py-0.5 px-3 border rounded-md text-lg">함께한 참여자</p>
+            <p className="w-[150px] text-left">유저 100</p>
+          </div>
+        </div>
+      </div>
+      <div className="flex items-end justify-center flex-col mt-8">
+        <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
+          보기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/historyPage/HistoryList.tsx
+++ b/src/components/historyPage/HistoryList.tsx
@@ -1,125 +1,4 @@
-// import { Link } from 'react-router-dom';
-// import { Carousel, CarouselContent, CarouselItem, CarouselNext, CarouselPrevious } from '@/components/ui/carousel';
-// import { Card, CardContent } from '@/components/ui/card';
-
 import { Link } from 'react-router-dom';
-
-// export default function HistoryList() {
-//   return (
-//     <div className="w-full">
-//       <div className="flex w-full justify-center flex-col border-b border-slate-200 py-6">
-//         <div className="flex justify-center items-center gap-14">
-//           <div className="flex justify-center">
-//             <Carousel className="w-full max-w-sm">
-//               <CarouselContent>
-//                 <CarouselItem>
-//                   <div className="p-1">
-//                     <Card>
-//                       <CardContent className="flex aspect-square items-center justify-center p-6">
-//                         <div className="w-24 h-48 justify-center bg-no-repeat bg-cover bg-center" />
-//                       </CardContent>
-//                     </Card>
-//                   </div>
-//                 </CarouselItem>
-//               </CarouselContent>
-//               <CarouselPrevious className="bg-slate-200" />
-//               <CarouselNext className="bg-slate-200" />
-//             </Carousel>
-//           </div>
-//           <ul className="flex justify-center border-slate-200 gap-20">
-//             <div className="ml-6 my-6">
-//               <section className="grid grid-cols-1 gap-5 ">
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">게시글 제목</div>
-//                   <div className="h-fit">휴지를 함께 사실 분을 모집합니다!</div>
-//                 </li>
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께 산 상품</div>
-//                   <div className="flex flex-col gap-1">
-//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">크리오덴티메이트 칫솔</div>
-//                   </div>
-//                 </li>
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품링크</div>
-//                   <div className="flex flex-col gap-1">
-//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">https://zero-base.co.kr/</div>
-//                   </div>
-//                 </li>
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께한 참여자</div>
-//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 1</div>
-//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 2</div>
-//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 3</div>
-//                 </li>
-//               </section>
-//             </div>
-//           </ul>
-//         </div>
-//         <div className="flex items-end justify-center flex-col mt-8">
-//           <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
-//             보기
-//           </Link>
-//         </div>
-//       </div>
-//       <div className="flex justify-center w-full flex-col border-b border-slate-200 py-6">
-//         <div className="flex justify-center items-center gap-14">
-//           <div className="flex justify-center">
-//             <Carousel className="w-full max-w-sm">
-//               <CarouselContent>
-//                 <CarouselItem>
-//                   <div className="p-1">
-//                     <Card>
-//                       <CardContent className="flex aspect-square items-center justify-center p-6">
-//                         <div className="w-24 h-48 justify-center bg-no-repeat bg-cover bg-center" />
-//                       </CardContent>
-//                     </Card>
-//                   </div>
-//                 </CarouselItem>
-//               </CarouselContent>
-//               <CarouselPrevious />
-//               <CarouselNext />
-//             </Carousel>
-//           </div>
-//           <ul className="flex justify-center border-slate-200 gap-20">
-//             <div className="ml-6 my-6">
-//               <section className="grid grid-cols-1 gap-5 ">
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">게시글 제목</div>
-//                   <div className="h-fit">칫솔과 휴지를 함께 사실 분을 모집합니다!</div>
-//                 </li>
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께 산 상품</div>
-//                   <div className="flex flex-col gap-1">
-//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">크리오덴티메이트 칫솔</div>
-//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">크리오덴티메이트 칫솔</div>
-//                   </div>
-//                 </li>
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">제품링크</div>
-//                   <div className="flex flex-col gap-1">
-//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">https://zero-base.co.kr/</div>
-//                     <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">https://zero-base.co.kr/</div>
-//                   </div>
-//                 </li>
-//                 <li className="flex gap-5">
-//                   <div className="text-dark-gray font-bold w-24 flex-shrink-0">함께한 참여자</div>
-//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 1</div>
-//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 2</div>
-//                   <div className="h-fit px-[6px] py-[2px] bg-slate-200 rounded-sm">유저 3</div>
-//                 </li>
-//               </section>
-//             </div>
-//           </ul>
-//         </div>
-//         <div className="flex items-end justify-center flex-col mt-8">
-//           <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
-//             보기
-//           </Link>
-//         </div>
-//       </div>
-//     </div>
-//   );
-// }
 
 export default function HistoryList() {
   return (
@@ -129,7 +8,7 @@ export default function HistoryList() {
         className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
       >
         <div className="flex items-center gap-x-2">
-          <h2 className="font-bold">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
+          <h2 className="font-bold text-base">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
         </div>
         <div className="flex">
           <ul className="flex flex-col gap-2 text-sm opacity-50">
@@ -137,10 +16,6 @@ export default function HistoryList() {
               <div className="font-bold flex-shrink-0 ">함께 산 상품</div>
               <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
               <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
-            </li>
-            <li className="flex gap-2 py-[2px]">
-              <div className="font-bold flex-shrink-0 ">제품링크</div>
-              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">https://zero-base.co.kr/</div>
             </li>
             <li className="flex gap-2 py-[2px]">
               <div className="font-bold flex-shrink-0 ">모집상태</div>
@@ -153,9 +28,6 @@ export default function HistoryList() {
               <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 3</div>
             </li>
           </ul>
-        </div>
-        <div className="flex items-end justify-center flex-col">
-          <button className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">보기</button>
         </div>
       </Link>
       <Link
@@ -163,7 +35,7 @@ export default function HistoryList() {
         className="w-full flex flex-col border-light-gray first-of-type:border-t-[1px] border-b-[1px] hover:bg-secondary gap-y-2 transition-all p-4"
       >
         <div className="flex items-center gap-x-2">
-          <h2 className="font-bold">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
+          <h2 className="font-bold text-base">칫솔과 휴지를 함께 사실 분을 모집합니다!</h2>
         </div>
         <div className="flex">
           <ul className="flex flex-col gap-2 text-sm opacity-50">
@@ -171,10 +43,6 @@ export default function HistoryList() {
               <div className="font-bold flex-shrink-0 ">함께 산 상품</div>
               <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
               <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">크리오덴티메이트 칫솔</div>
-            </li>
-            <li className="flex gap-2 py-[2px]">
-              <div className="font-bold flex-shrink-0 ">제품링크</div>
-              <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">https://zero-base.co.kr/</div>
             </li>
             <li className="flex gap-2 py-[2px]">
               <div className="font-bold flex-shrink-0 ">모집상태</div>
@@ -187,9 +55,6 @@ export default function HistoryList() {
               <div className="bg-slate-200 rounded-sm text-center py-[2px] px-[6px]">유저 3</div>
             </li>
           </ul>
-        </div>
-        <div className="flex items-end justify-center flex-col">
-          <button className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">보기</button>
         </div>
       </Link>
     </div>

--- a/src/components/postNewPage/Form.tsx
+++ b/src/components/postNewPage/Form.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
-import { FaMinus, FaPlus } from "react-icons/fa";
-import { DatePicker } from "../atoms/DatePicker";
+import { useEffect, useState } from 'react';
+import { FaMinus, FaPlus } from 'react-icons/fa';
+import { DatePicker } from '../atoms/DatePicker';
 import { format } from 'date-fns';
-import DaumPost from "../atoms/DaumPost";
-import { PostNew } from "@/lib/types";
-import Category from "./Category";
+import DaumPost from '../atoms/DaumPost';
+import { PostNew } from '@/lib/types';
+import Category from './Category';
+import axios from 'axios';
 
 export default function Form() {
   const [products, setProducts] = useState<PostNew[]>([
@@ -19,7 +20,7 @@ export default function Form() {
       purchaseLink: '',
       productImgUrl: '',
       content: '',
-      category: "ALL"
+      category: 'ALL',
     },
   ]);
 
@@ -32,7 +33,7 @@ export default function Form() {
 
   const handleCategorySelect = (category: string) => {
     setSelectedCategory(category);
-  }
+  };
 
   /**
    * 새로운 입력 필드 추가
@@ -56,7 +57,7 @@ export default function Form() {
         deadline: '',
         place: '',
         content: '',
-        category: "ALL"
+        category: 'ALL',
       },
     ]);
   };
@@ -71,7 +72,7 @@ export default function Form() {
   // 게시글 변경
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
-  }
+  };
 
   // 상품 이름 변경
   const handleProductNameChange = (index: number, value: string) => {
@@ -85,7 +86,6 @@ export default function Form() {
     const newProducts = [...products];
     newProducts[index].purchaseLink = value;
     setProducts(newProducts);
-    // fetchProductImage(index, value);
   };
 
   /**
@@ -115,9 +115,9 @@ export default function Form() {
   const handleProductPriceChange = (index: number, value: string) => {
     // 입력된 값이 숫자인지 확인하고, 숫자가 아니면 빈 문자열로 설정
     const newValue = value.trim() === '' ? '0' : value.replaceAll(',', '');
-  
+
     const newProducts = [...products];
-  
+
     // 상품의 가격 업데이트
     newProducts[index].price = parseInt(newValue);
     setProducts(newProducts);
@@ -146,16 +146,16 @@ export default function Form() {
    * 가격을 참여자 수로 나누어 인당 가격 계산
    * 인당 가격이 숫자가 아니면 빈 문자열 반환
    */
-  const calculatePerPersonPrice = ({price, participants}: PostNew): string => {
+  const calculatePerPersonPrice = ({ price, participants }: PostNew): string => {
     if (participants === 0) return '';
     const perPersonPrice = price / participants;
-    return isNaN(perPersonPrice) ? '' : (perPersonPrice).toLocaleString() + '원';
+    return isNaN(perPersonPrice) ? '' : perPersonPrice.toLocaleString() + '원';
   };
 
   // 주소 변경
   const handleAddressChange = (address: string) => {
-    setSelectedAddress(address)
-  }
+    setSelectedAddress(address);
+  };
 
   // 날짜 선택
   const handleDateSelect = (selectedDate: Date) => {
@@ -165,56 +165,66 @@ export default function Form() {
 
   // 상세정보 변경
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setContent(e.target.value)
-  }
+    setContent(e.target.value);
+  };
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    // 기본 폼 데이터 
-    const product = products[0];
-    // const { title, selectedAddress, content, selectedCategory, participants } = products;
-    const formattedDeadline = deadline ? format(new Date(deadline), 'yyyy-MM-dd HH:mm:ss') : '';
-
-    // 추가된 상품 데이터만 포함하는 배열
-    const addedProductsData = products.map(product => ({
-      productName: product.productName,
-      purchaseLink: product.purchaseLink,
-      count: product.count,
-      price: product.price,
-      productImgUrl: product.productImgUrl
-    }));
-
-    // 추가된 상품이 있는 경우, 해당 데이터를 포함하여 처리
-    if (addedProductsData.length > 0) {
-      // 추가된 상품 데이터와 나머지 폼 데이터를 포함한 얼럿 메세지
-      alert(`title: ${title}, products: ${JSON.stringify(addedProductsData)}, place: ${selectedAddress}, content: ${content}, category: ${selectedCategory}`)
-    } else {
-      // 추가된 상품이 없는 경우, 기존 폼 데이터만 포함한 얼럿 메세지
-      alert(`title: ${title}, name: ${product.productName}, link: ${product.purchaseLink}, count: ${product.count}, price: ${product.price}, participants: ${product.participants}, place: ${selectedAddress}, deadline: ${formattedDeadline}, content: ${content}, category: ${selectedCategory} productImgUrl: ${product.productImgUrl}`);
-    }
-  }
-  
-  // TODO: 'multipart/form-data' 사용해서 이미지 업로드하기
+  // TODO: 이미지 미리보기 안되는 이유 찾기 (원래는 미리보기가 가능했었음)
   const [imageFile, setImageFiles] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState('');
 
-  const uploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     console.log('file', file);
 
-    const formData = new FormData();
-    imageFile && formData.append('image', imageFile);
-    console.log('formData', ...formData);
-
     if (file) {
-      setImageFiles(file);
-      
       const productImgUrl = URL.createObjectURL(file);
+      setImageFiles(file);
       setImagePreview(productImgUrl);
       console.log('productImgUrl', productImgUrl);
-    };
-    
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement> | React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    const formData = new FormData();
+    formData.append('category', selectedCategory);
+    formData.append('title', title);
+    formData.append('deadline', format(new Date(deadline), 'yyyy-MM-dd HH:mm:ss'));
+    formData.append('participants', totalParticipants);
+    formData.append('place', selectedAddress);
+    formData.append('content', content);
+
+    products.forEach((product, index) => {
+      if (imageFile) {
+        const productImgUrl = URL.createObjectURL(imageFile);
+        formData.append(`products[${index}][productImgUrl]`, productImgUrl);
+      }
+      formData.append(`products[${index}][productName]`, product.productName);
+      formData.append(`products[${index}][price]`, product.price.toString());
+      formData.append(`products[${index}][count]`, product.count.toString());
+      formData.append(`products[${index}][purchaseLink]`, product.purchaseLink);
+      // formData.append(`products[${index}][productImgUrl]`, product.productImgUrl);
+    });
+
+    try {
+      const response = await axios.post('/post/new', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      console.log('응답: ', response.data);
+    } catch (error) {
+      console.error('에러 발생: ', error);
+    }
+
+    if (imageFile) {
+      const productImgUrl = URL.createObjectURL(imageFile);
+      setImageFiles(imageFile);
+      setImagePreview(productImgUrl);
+      console.log('productImgUrl', productImgUrl);
+    }
   };
 
   // 메모리 누수 방지 - 이미지 업로드 후 Blob URL 해제
@@ -226,9 +236,19 @@ export default function Form() {
 
   return (
     <form onSubmit={handleSubmit} method="POST" encType="multipart/form-data">
-      <input type="submit" value={'등록'} className="absolute right-0 top-0 py-0.5 px-3 bg-primary rounded-md text-white my-[15px] mr-5" />
+      <input
+        type="submit"
+        value={'등록'}
+        className="absolute right-0 top-0 py-0.5 px-3 bg-primary rounded-md text-white my-[15px] mr-5"
+      />
       <Category onSelectCategory={handleCategorySelect} />
-      <input type="text" placeholder="게시글 제목" value={title} onChange={handleTitleChange} className="w-full outline-none py-4 border-b" />
+      <input
+        type="text"
+        placeholder="게시글 제목"
+        value={title}
+        onChange={handleTitleChange}
+        className="w-full outline-none py-4 border-b"
+      />
       {products.map((product, index) => (
         <div key={index}>
           <div className="flex items-center justify-between py-4 border-b text-black">
@@ -271,28 +291,29 @@ export default function Form() {
             <input
               type="text"
               placeholder="원래 가격"
-              value={(product.price) === 0 ? '' : (product.price).toLocaleString()}
+              value={product.price === 0 ? '' : product.price.toLocaleString()}
               onChange={e => handleProductPriceChange(index, e.target.value.replaceAll(',', ''))}
               className="w-full outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-            />원
+            />
+            원
           </div>
           {index === products.length - 1 ? (
             <input
-            type="text"
-            key={index}
-            placeholder="인당 가격"
-            value={calculatePerPersonPrice(product)}
-            readOnly
-            className="w-full outline-none py-4 border-b"
+              type="text"
+              key={index}
+              placeholder="인당 가격"
+              value={calculatePerPersonPrice(product)}
+              readOnly
+              className="w-full outline-none py-4 border-b"
             />
           ) : (
             <input
-            type="text"
-            key={index}
-            placeholder="인당 가격"
-            value={calculatePerPersonPrice(product)}
-            readOnly
-            className="w-full outline-none py-4 border-b-2 border-stone-300 text-black"
+              type="text"
+              key={index}
+              placeholder="인당 가격"
+              value={calculatePerPersonPrice(product)}
+              readOnly
+              className="w-full outline-none py-4 border-b-2 border-stone-300 text-black"
             />
           )}
         </div>
@@ -306,7 +327,7 @@ export default function Form() {
         className="w-full outline-none py-4 border-b [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
       />
       <div className="w-full border-b py-4">
-        <DatePicker onDateChange={handleDateSelect}  />
+        <DatePicker onDateChange={handleDateSelect} />
       </div>
       <textarea
         cols={30}
@@ -319,18 +340,30 @@ export default function Form() {
       />
       <div className="flex w-full py-4 border-b">
         <p className="text-[#C4C4C4] font-semibold mr-4">사진</p>
-        {/* {products.map((product, index) => ( */}
-          <div className="flex justify-center mr-3">
-            {/* {product.productImgUrl ? (
-              <img src={product.productImgUrl} alt={product.productName} className="w-[53px] h-[53px] border" />
+        <div className="flex justify-center mr-3">
+          {products.map((product, index) => (
+            <div key={index}>
+              {product.productImgUrl ? (
+                <img src={imagePreview} alt="Uploaded Preview" className="w-[53px] h-[53px] border" />
               ) : (
-              <div className="flex items-center justify-center w-[53px] h-[53px] border bg-gray-300">+</div>
-            )} */}
-            <img src={imagePreview} alt='상품이미지' />
-            <input type="file" accept="'image/*" onChange={uploadImage} />
-          </div>
-        {/* ))} */}
+                <label
+                  htmlFor={`file-upload-${index}`}
+                  className="flex items-center justify-center w-[53px] h-[53px] border bg-gray-300 cursor-pointer"
+                >
+                  +
+                </label>
+              )}
+              <input
+                type="file"
+                id={`file-upload-${index}`}
+                accept="'image/*"
+                onChange={handleImageChange}
+                className="hidden"
+              />
+            </div>
+          ))}
+        </div>
       </div>
     </form>
-  )
+  );
 }

--- a/src/components/profilePage/EditProfile.tsx
+++ b/src/components/profilePage/EditProfile.tsx
@@ -6,7 +6,7 @@ export default function EditProfile() {
           <img src="" alt="" className="w-[100px] h-[100px] bg-gray-500 rounded-[50%]" />
           <label
             htmlFor={`edit-image`}
-            className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white"
+            className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white cursor-pointer"
           >
             사진변경
           </label>

--- a/src/components/profilePage/EditProfile.tsx
+++ b/src/components/profilePage/EditProfile.tsx
@@ -1,0 +1,3 @@
+export default function EditProfile() {
+  return <>프로필 수정페이지</>;
+}

--- a/src/components/profilePage/EditProfile.tsx
+++ b/src/components/profilePage/EditProfile.tsx
@@ -1,41 +1,21 @@
+import { FaLongArrowAltLeft } from 'react-icons/fa';
+import { Link } from 'react-router-dom';
+import EditProfileForm from './EditProfileForm';
+
 export default function EditProfile() {
   return (
-    <form className="flex items-center justify-center flex-col">
-      <div className="flex w-full items-center justify-center py-6">
-        <div className="w-full flex flex-col items-center justify-center gap-6">
-          <img src="" alt="" className="w-[100px] h-[100px] bg-gray-500 rounded-[50%]" />
-          <label
-            htmlFor={`edit-image`}
-            className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white cursor-pointer"
-          >
-            사진변경
-          </label>
-          <input type="file" id="edit-image" accept="'image/*" className="hidden" />
+    <section className="px-5 w-full">
+      <div className="flex items-center justify-between border-b border-black h-[60px]">
+        <div className="flex items-center gap-2.5">
+          <Link to="/my">
+            <FaLongArrowAltLeft className="w-5 h-5" />
+          </Link>
+          <h3 className="font-semibold">프로필 수정</h3>
         </div>
       </div>
-      <div className="w-full flex items-center justify-center gap-5 border-b">
-        <p className="w-[100px]">닉네임</p>
-        <input type="text" placeholder="닉네임" className="outline-none py-4 " />
+      <div>
+        <EditProfileForm />
       </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px]">비밀번호</p>
-        <input type="text" placeholder="비밀번호 입력" className="outline-none" />
-      </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px]">비밀번호 확인</p>
-        <input type="text" placeholder="비밀번호 확인" className="outline-none" />
-      </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px]">주소</p>
-        <input type="text" placeholder="주소" className="outline-none" />
-      </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px]">전화번호</p>
-        <input type="text" placeholder="전화번호 입력" className="outline-none" />
-      </div>
-      <button className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 rounded-md text-white mt-28 bg-[#F94A3F]">
-        회원탈퇴
-      </button>
-    </form>
+    </section>
   );
 }

--- a/src/components/profilePage/EditProfile.tsx
+++ b/src/components/profilePage/EditProfile.tsx
@@ -1,3 +1,41 @@
 export default function EditProfile() {
-  return <>프로필 수정페이지</>;
+  return (
+    <form className="flex items-center justify-center flex-col">
+      <div className="flex w-full items-center justify-center py-6">
+        <div className="w-full flex flex-col items-center justify-center gap-6">
+          <img src="" alt="" className="w-[100px] h-[100px] bg-gray-500 rounded-[50%]" />
+          <label
+            htmlFor={`edit-image`}
+            className="flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white"
+          >
+            사진변경
+          </label>
+          <input type="file" id="edit-image" accept="'image/*" className="hidden" />
+        </div>
+      </div>
+      <div className="w-full flex items-center justify-center gap-5 border-b">
+        <p className="w-[100px]">닉네임</p>
+        <input type="text" placeholder="닉네임" className="outline-none py-4 " />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">비밀번호</p>
+        <input type="text" placeholder="비밀번호 입력" className="outline-none" />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">비밀번호 확인</p>
+        <input type="text" placeholder="비밀번호 확인" className="outline-none" />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">주소</p>
+        <input type="text" placeholder="주소" className="outline-none" />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">전화번호</p>
+        <input type="text" placeholder="전화번호 입력" className="outline-none" />
+      </div>
+      <button className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 rounded-md text-white mt-28 bg-[#F94A3F]">
+        회원탈퇴
+      </button>
+    </form>
+  );
 }

--- a/src/components/profilePage/EditProfile.tsx
+++ b/src/components/profilePage/EditProfile.tsx
@@ -6,7 +6,7 @@ export default function EditProfile() {
           <img src="" alt="" className="w-[100px] h-[100px] bg-gray-500 rounded-[50%]" />
           <label
             htmlFor={`edit-image`}
-            className="flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white"
+            className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white"
           >
             사진변경
           </label>

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -1,0 +1,46 @@
+export default function EditProfileForm() {
+  return (
+    <form className="flex items-center justify-center flex-col">
+      <input
+        type="submit"
+        value={'완료'}
+        className="absolute right-0 top-0 py-0.5 px-3 bg-primary rounded-md text-white my-[15px] mr-5"
+      />
+      <div className="flex w-full items-center justify-center py-6">
+        <div className="w-full flex flex-col items-center justify-center gap-6">
+          <img src="" alt="" className="w-[100px] h-[100px] bg-gray-500 rounded-[50%]" />
+          <label
+            htmlFor={`edit-image`}
+            className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white cursor-pointer"
+          >
+            사진변경
+          </label>
+          <input type="file" id="edit-image" accept="'image/*" className="hidden" />
+        </div>
+      </div>
+      <div className="w-full flex items-center justify-center gap-5 border-b">
+        <p className="w-[100px]">닉네임</p>
+        <input type="text" placeholder="닉네임" className="outline-none py-4 " />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">비밀번호</p>
+        <input type="text" placeholder="비밀번호 입력" className="outline-none" />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">비밀번호 확인</p>
+        <input type="text" placeholder="비밀번호 확인" className="outline-none" />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">주소</p>
+        <input type="text" placeholder="주소" className="outline-none" />
+      </div>
+      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+        <p className="w-[100px]">전화번호</p>
+        <input type="text" placeholder="전화번호 입력" className="outline-none" />
+      </div>
+      <button className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 rounded-md text-white mt-28 bg-[#F94A3F]">
+        회원탈퇴
+      </button>
+    </form>
+  );
+}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -2,7 +2,7 @@ import HistoryList from '@/components/historyPage/HistoryList';
 
 export default function HistoryPage() {
   return (
-    <section className="flex justify-center items-center flex-col mt-8">
+    <section className="h-full flex justify-center items-center flex-col mt-8">
       <h1 className="font-bold text-3xl">참여내역</h1>
       <HistoryList />
     </section>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,37 +1,10 @@
-import { Link } from 'react-router-dom';
+import HistoryList from '@/components/historyPage/HistoryList';
 
 export default function HistoryPage() {
   return (
     <section className="flex justify-center items-center flex-col mt-8">
       <h1 className="font-bold text-3xl">참여내역</h1>
-      <div className="flex w-full flex-col mt-10">
-        <div className="flex justify-center gap-7 mt-10">
-          <div className="w-36 h-36 bg-gray-500 "></div>
-          <div>
-            <div className="flex items-center justify-between gap-10 mb-3">
-              <p className="py-0.5 px-3 border rounded-md text-lg">제품명</p>
-              <p className="w-[150px] text-left">휴지</p>
-            </div>
-            <div className="flex items-center justify-between gap-10 mb-3">
-              <p className="py-0.5 px-3 border rounded-md text-lg">제품 링크</p>
-              <p className="w-[150px] text-left">https</p>
-            </div>
-            <div className="flex items-center justify-between gap-10 mb-3">
-              <p className="py-0.5 px-3 border rounded-md text-lg">상태</p>
-              <p className="w-[150px] text-left">모집중</p>
-            </div>
-            <div className="flex items-center justify-between gap-10 mb-3">
-              <p className="py-0.5 px-3 border rounded-md text-lg">함께한 참여자</p>
-              <p className="w-[150px] text-left">유저 100</p>
-            </div>
-          </div>
-        </div>
-        <div className="flex items-end justify-center flex-col mt-8">
-          <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
-            보기
-          </Link>
-        </div>
-      </div>
+      <HistoryList />
     </section>
   );
 }

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,0 +1,3 @@
+export default function HistoryPage() {
+  return <div>참여내역 페이지</div>;
+}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,3 +1,37 @@
+import { Link } from 'react-router-dom';
+
 export default function HistoryPage() {
-  return <div>참여내역 페이지</div>;
+  return (
+    <section className="flex justify-center items-center flex-col mt-8">
+      <h1 className="font-bold text-3xl">참여내역</h1>
+      <div className="flex w-full flex-col mt-10">
+        <div className="flex justify-center gap-7 mt-10">
+          <div className="w-36 h-36 bg-gray-500 "></div>
+          <div>
+            <div className="flex items-center justify-between gap-10 mb-3">
+              <p className="py-0.5 px-3 border rounded-md text-lg">제품명</p>
+              <p className="w-[150px] text-left">휴지</p>
+            </div>
+            <div className="flex items-center justify-between gap-10 mb-3">
+              <p className="py-0.5 px-3 border rounded-md text-lg">제품 링크</p>
+              <p className="w-[150px] text-left">https</p>
+            </div>
+            <div className="flex items-center justify-between gap-10 mb-3">
+              <p className="py-0.5 px-3 border rounded-md text-lg">상태</p>
+              <p className="w-[150px] text-left">모집중</p>
+            </div>
+            <div className="flex items-center justify-between gap-10 mb-3">
+              <p className="py-0.5 px-3 border rounded-md text-lg">함께한 참여자</p>
+              <p className="w-[150px] text-left">유저 100</p>
+            </div>
+          </div>
+        </div>
+        <div className="flex items-end justify-center flex-col mt-8">
+          <Link to="/my/history/:postId" className="flex justify-center py-0.5 px-3 bg-primary rounded-md text-white">
+            보기
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -9,6 +9,9 @@ export default function MyPage() {
       <Link className="bg-slate-200 text-primary px-2 py-1" to="/my/profile">
         프로필 조회를 위한 임시 버튼
       </Link>
+      <Link className="bg-slate-200 text-primary px-2 py-1" to="/my/history">
+        참여내역 조회를 위한 임시 버튼
+      </Link>
     </div>
   );
 }

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -6,6 +6,9 @@ export default function MyPage() {
       <Link className="bg-slate-200 text-primary px-2 py-1" to="/my/bookmark">
         북마크 조회를 위한 임시 버튼
       </Link>
+      <Link className="bg-slate-200 text-primary px-2 py-1" to="/my/profile">
+        프로필 조회를 위한 임시 버튼
+      </Link>
     </div>
   );
 }

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+
+export default function ProfilePage() {
+  return (
+    <section className="flex justify-center items-center flex-col mt-8">
+      <h1 className="font-bold text-3xl">프로필</h1>
+      <div className="flex items-center flex-col mt-10">
+        <div className="w-36 h-36 bg-gray-500 rounded-[50%]"></div>
+        <div className="flex items-center justify-between mt-8 gap-10">
+          <p className="py-0.5 px-3 border rounded-md text-lg">닉네임</p>
+          <p>유저 닉네임</p>
+        </div>
+        <div className="flex items-center justify-between mt-8 gap-10">
+          <p className="py-0.5 px-3 border rounded-md text-lg">매너점수</p>
+          <span>*****</span>
+        </div>
+        <div className="flex items-center justify-center flex-col mt-8">
+          <Link to="/my/edit/Profile" className="py-0.5 px-3 bg-primary rounded-md text-white">
+            수정하기
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/PostNewPage.tsx
+++ b/src/pages/PostNewPage.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import Form from '@/components/postNewPage/Form';
 
 export default function PostNewPage() {
-
   return (
     <section className="px-5 w-full">
       <div className="flex items-center justify-between border-b border-black h-[60px]">


### PR DESCRIPTION
## 연관 이슈
#43 

### 요약

- 참여내역 페이지 UI

### 타입

- [x] feat : 새로운 기능 추가, 기존의 기능을 요구 사항에 맞추어 수정
- [ ] fix : 기능에 대한 버그, 오류 수정
- [ ] add : feat 이외의 부수적인 코드 추가, 라이브러리 추가
- [ ] build : 빌드 관련 수정
- [ ] chore : 프로덕션 코드 외 빌드 부분 혹은 패키지 매니저 수정사항 (ex. .gitignore)
- [x] design : css 및 레이아웃 작업
- [ ] docs : 문서,주석 수정
- [ ] style : 코드 스타일, 포맷팅에 대한 수정
- [ ] refactor : 기능의 변화가 아닌 코드 리팩터링 (ex. 변수 이름 변경)
- [ ] test : 테스트 코드 추가/수정

### 작업 내용

- 참여내역 페이지 UI
- 참여내역 상세 페이지 UI

### 스크린샷(선택)
- 참여내역 페이지 UI 
![참여내역 페이지](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/4336d28d-230f-417e-b232-4a96207a368d)


- 참여내역 상세페이지 UI
![참여내역 상세페이지](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/4755800a-0c45-45f8-9230-c52dcacb5f2d)


### 논의하고 싶은 부분
- 논의완료
> 참여내역 페이지 UI 변경에 대해서 논의하고 싶습니다.
스크린샷을 보면 캐러셀(제품 이미지) 들어가게 되면 UI가 이쁘지않아서
차라리 게시글 목록 페이지처럼 UI를 변경하는 것은 어떻게 생각하실까요?
제 생각에는 사이트 전체의 통일성 측면에서도 게시글 목록 페이지처럼 UI를 구현하는 것이 좋을 것 같습니다..!

> 참여내역 상세 페이지 UI를 게시글 상세페이지와 비슷하게 만들었습니다.
그리고 목록으로 돌아가는 버튼도 추가했습니다.
레이아웃 수정 또는 논의하실 내용있으시면 코멘트 달아주세요!

- 추가 논의 사항
> 참여내역 상세페이지에서 상세정보를 보여주지 않아도 괜찮겠죠?