### PR TITLE
Feat: 프로필 페이지

### DIFF
--- a/src/apis/myPage/profiles.ts
+++ b/src/apis/myPage/profiles.ts
@@ -1,0 +1,16 @@
+import { axiosAccessFn } from '../apiClient';
+
+const axiosAccess = axiosAccessFn();
+
+export const getProfiles = async () => {
+  try {
+    const res = await axiosAccess({
+      method: 'get',
+      url: '/users/profiles',
+    });
+
+    return res;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/apis/myPage/profiles.ts
+++ b/src/apis/myPage/profiles.ts
@@ -9,7 +9,7 @@ export const getProfiles = async () => {
       url: '/users/profiles',
     });
 
-    return res;
+    return res.data;
   } catch (error) {
     throw error;
   }

--- a/src/apis/myPage/profiles.ts
+++ b/src/apis/myPage/profiles.ts
@@ -14,3 +14,16 @@ export const getProfiles = async () => {
     throw error;
   }
 };
+
+export const getEditProfiles = async () => {
+  try {
+    const res = await axiosAccess({
+      method: 'get',
+      url: '/users/profiles/update',
+    });
+
+    return res.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/components/profilePage/DaumPost.tsx
+++ b/src/components/profilePage/DaumPost.tsx
@@ -1,4 +1,4 @@
-import { PostNew } from '@/lib/types';
+import { PostNew } from '@/types/post';
 import { ChangeEvent, useState } from 'react';
 import DaumPostcode from 'react-daum-postcode';
 

--- a/src/components/profilePage/DaumPost.tsx
+++ b/src/components/profilePage/DaumPost.tsx
@@ -1,0 +1,69 @@
+import { PostNew } from '@/lib/types';
+import { ChangeEvent, useState } from 'react';
+import DaumPostcode from 'react-daum-postcode';
+
+export default function DaumPost({ onAddressChange }: { onAddressChange: (address: PostNew['place']) => void }) {
+  // 주소, 모달 열림 여부, 상세 주소 상태 관리
+  const [address, setAddress] = useState('');
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  // 주소 검색 완료 시 호출되는 콜백 함수
+  const handleComplete = (data: { address: string }) => {
+    const { address } = data;
+    setIsOpen(false);
+    setAddress(address);
+    onAddressChange(address);
+
+    // 데이터 확인
+    console.log(data, 'data');
+  };
+
+  // 주소 검색 모달이 닫힐 때 호출되는 콜백 함수
+  const handleClose = (state: string) => {
+    // 모달이 강제로 닫힌 경우 또는 주소 선택 완료 후 모달 닫기
+    if (state === 'FORCE_CLOSE') {
+      setIsOpen(false);
+      console.log('FORCE_CLOSE');
+    } else if (state === 'COMPLETE_CLOSE') {
+      setIsOpen(false);
+      console.log('COMPLETE_CLOSE');
+    }
+  };
+
+  // 모달 토글
+  const toggleHandler = () => {
+    setIsOpen(prevOpenState => !prevOpenState);
+  };
+
+  // 상세 주소 입력값이 변경될 때 호출되는 함수
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setAddress(event.target.value);
+  };
+
+  return (
+    <div>
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="주소"
+          value={address}
+          onChange={handleInputChange}
+          readOnly
+          className="w-[250px] outline-none"
+        />
+        <button
+          type="button"
+          onClick={toggleHandler}
+          className="w-[90px] py-1 px-3 bg-primary border-none rounded-md text-white outline-0"
+        >
+          주소 찾기
+        </button>
+        {isOpen && (
+          <div className="absolute left-0 top-full border">
+            <DaumPostcode onComplete={handleComplete} onClose={handleClose} autoMapping />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/profilePage/EditProfile.tsx
+++ b/src/components/profilePage/EditProfile.tsx
@@ -4,7 +4,7 @@ import EditProfileForm from './EditProfileForm';
 
 export default function EditProfile() {
   return (
-    <section className="px-5 w-full">
+    <section className="px-5 w-full h-screen">
       <div className="flex items-center justify-between border-b border-black h-[60px]">
         <div className="flex items-center gap-2.5">
           <Link to="/my/profile">

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -6,6 +6,8 @@ import { useEffect, useRef, useState } from 'react';
 import { MdAddAPhoto } from 'react-icons/md';
 import DaumPost from './DaumPost';
 
+// TODO: 컴포넌트 분리하기
+// TODO: 회원탈퇴 기능 구현하기
 export default function EditProfileForm() {
   const profileImgFileInput = useRef(null);
   const [profiles, setProfiles] = useState<EditProfile[]>([]);
@@ -14,6 +16,9 @@ export default function EditProfileForm() {
   const [nickname, setNickname] = useState('');
   const [location, setLocation] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordMatch, setPasswordMatch] = useState<boolean>(true);
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['profiles/update'],
@@ -38,7 +43,6 @@ export default function EditProfileForm() {
     setNickname(e.target.value);
   };
 
-  // 주소 변경
   const handleAddressChange = (address: string) => {
     setLocation(address);
   };
@@ -47,13 +51,30 @@ export default function EditProfileForm() {
     setPhoneNumber(e.target.value);
   };
 
+  const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    // setPasswordMatch(e.target.value === confirmPassword);
+  };
+
+  const handleConfirmPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setConfirmPassword(e.target.value);
+    setPasswordMatch(e.target.value === password);
+  };
+
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement> | React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
+
+    if (password !== confirmPassword) {
+      setPasswordMatch(false);
+      return;
+    }
 
     const formData = new FormData();
     formData.append('nickname', nickname);
     formData.append('location', location);
     formData.append('phoneNumber', phoneNumber);
+    formData.append('password', password);
+    formData.append('confirmPassword', confirmPassword);
     if (imageFile) {
       const profileImgUrl = URL.createObjectURL(imageFile);
       formData.append('profileImg', profileImgUrl);
@@ -158,6 +179,8 @@ export default function EditProfileForm() {
                 placeholder="비밀번호 입력"
                 minLength={8}
                 maxLength={16}
+                value={password}
+                onChange={handlePasswordChange}
                 className="w-[250px] outline-none"
               />
             </div>
@@ -168,8 +191,11 @@ export default function EditProfileForm() {
                 placeholder="비밀번호 확인"
                 minLength={8}
                 maxLength={16}
+                value={confirmPassword}
+                onChange={handleConfirmPasswordChange}
                 className="w-[250px] outline-none"
               />
+              {!passwordMatch && <p className="text-red-500">입력하신 비밀번호가 일치하지 않습니다.</p>}
             </div>
             <div className="w-full flex items-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">주소</p>

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -6,23 +6,13 @@ import { useEffect, useRef, useState } from 'react';
 import { MdAddAPhoto } from 'react-icons/md';
 
 export default function EditProfileForm() {
-  const [profiles, setProfiles] = useState<EditProfile[]>([]);
   const profileImgFileInput = useRef(null);
+  const [profiles, setProfiles] = useState<EditProfile[]>([]);
   const [imageFile, setImageFiles] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState('');
   const [nickname, setNickname] = useState('');
   const [location, setLocation] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
-  console.log(
-    '이미지 파일 정보 확인',
-    imageFile,
-    'nickname: ',
-    nickname,
-    'location: ',
-    location,
-    'phoneNumber: ',
-    phoneNumber,
-  );
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['profiles/update'],
@@ -75,11 +65,10 @@ export default function EditProfileForm() {
       });
 
       console.log('응답: ', response.data);
+      alert('프로필 수정이 완료되었습니다.');
     } catch (error) {
       console.error('에러 발생: ', error);
     }
-
-    alert(`nickname: ${nickname}, location: ${location}, phoneNumber: ${phoneNumber}`);
   };
 
   useEffect(() => {

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -1,11 +1,28 @@
 import { getEditProfiles } from '@/apis/myPage/profiles';
 import { EditProfile } from '@/mocks/handlers/myPage/profile';
 import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { MdAddAPhoto } from 'react-icons/md';
 
 export default function EditProfileForm() {
   const [profiles, setProfiles] = useState<EditProfile[]>([]);
+  const profileImgFileInput = useRef(null);
+  const [imageFile, setImageFiles] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState('');
+  const [nickname, setNickname] = useState('');
+  const [location, setLocation] = useState('');
+  const [phoneNumber, setPhoneNumber] = useState('');
+  console.log(
+    '이미지 파일 정보 확인',
+    imageFile,
+    'nickname: ',
+    nickname,
+    'location: ',
+    location,
+    'phoneNumber: ',
+    phoneNumber,
+  );
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['profiles/update'],
@@ -14,21 +31,55 @@ export default function EditProfileForm() {
     },
   });
 
-  const profileImgFileInput = useRef(null);
-  const [imageFile, setImageFiles] = useState<File | null>(null);
-  const [imagePreview, setImagePreview] = useState('');
-  console.log('이미지 파일 정보 확인', imageFile);
-
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     console.log('file', file);
 
     if (file) {
-      const productImgUrl = URL.createObjectURL(file);
+      const profileImgUrl = URL.createObjectURL(file);
       setImageFiles(file);
-      setImagePreview(productImgUrl);
-      console.log('productImgUrl', productImgUrl);
+      setImagePreview(profileImgUrl);
+      console.log('productImgUrl', profileImgUrl);
     }
+  };
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
+  const handleLocationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLocation(e.target.value);
+  };
+
+  const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPhoneNumber(e.target.value);
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement> | React.ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+
+    const formData = new FormData();
+    formData.append('nickname', nickname);
+    formData.append('location', location);
+    formData.append('phoneNumber', phoneNumber);
+    if (imageFile) {
+      const profileImgUrl = URL.createObjectURL(imageFile);
+      formData.append('profileImg', profileImgUrl);
+    }
+
+    try {
+      const response = await axios.post('/users/:userId/profiles/update', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+
+      console.log('응답: ', response.data);
+    } catch (error) {
+      console.error('에러 발생: ', error);
+    }
+
+    alert(`nickname: ${nickname}, location: ${location}, phoneNumber: ${phoneNumber}`);
   };
 
   useEffect(() => {
@@ -47,7 +98,12 @@ export default function EditProfileForm() {
   if (error) return <div>프로필 정보를 가져오는데 실패하였습니다.</div>;
 
   return (
-    <form className="flex items-center justify-center flex-col">
+    <form
+      onSubmit={handleSubmit}
+      method="POST"
+      encType="multipart/form-data"
+      className="flex items-center justify-center flex-col"
+    >
       <input
         type="submit"
         value={'완료'}
@@ -72,7 +128,7 @@ export default function EditProfileForm() {
                         alt=""
                         className="flex items-center justify-center w-[100px] h-[100px] bg-slate-400 rounded-[50%]"
                       />
-                      <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />
+                      <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white opacity-70" />
                     </>
                   )}
                 </div>
@@ -95,23 +151,57 @@ export default function EditProfileForm() {
             </div>
             <div className="w-full flex items-center justify-center gap-5 border-b">
               <p className="w-[100px] font-bold">닉네임</p>
-              <input type="text" placeholder="닉네임" value={pf.nickname} className="outline-none py-4 " />
+              <input
+                type="text"
+                placeholder="닉네임"
+                defaultValue={pf.nickname}
+                name={nickname}
+                onChange={handleNicknameChange}
+                className="outline-none py-4 "
+              />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">비밀번호</p>
-              <input type="password" placeholder="비밀번호 입력" className="outline-none" />
+              <input
+                type="password"
+                placeholder="비밀번호 입력"
+                minLength={8}
+                maxLength={16}
+                className="outline-none"
+              />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">비밀번호 확인</p>
-              <input type="password" placeholder="비밀번호 확인" className="outline-none" />
+              <input
+                type="password"
+                placeholder="비밀번호 확인"
+                minLength={8}
+                maxLength={16}
+                className="outline-none"
+              />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">주소</p>
-              <input type="text" placeholder="주소" value={pf.location} className="outline-none" />
+              <input
+                type="text"
+                placeholder="주소"
+                defaultValue={pf.location}
+                name={location}
+                onChange={handleLocationChange}
+                className="outline-none"
+              />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">전화번호</p>
-              <input type="text" placeholder="전화번호 입력" value={pf.phoneNumber} className="outline-none" />
+              <input
+                type="text"
+                placeholder="전화번호 입력"
+                defaultValue={pf.phoneNumber}
+                name={phoneNumber}
+                onChange={handlePhoneNumberChange}
+                maxLength={11}
+                className="outline-none"
+              />
             </div>
           </div>
         ))}

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -1,4 +1,25 @@
+import { useRef, useState } from 'react';
+import { MdAddAPhoto } from 'react-icons/md';
+
 export default function EditProfileForm() {
+  const profileImgFileInput = useRef(null);
+  const [imageFile, setImageFiles] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState('');
+  console.log('이미지 파일 정보 확인', imageFile);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    console.log('file', file);
+
+    if (file) {
+      const productImgUrl = URL.createObjectURL(file);
+      setImageFiles(file);
+      setImagePreview(productImgUrl);
+      console.log('productImgUrl', productImgUrl);
+      console.log(``);
+    }
+  };
+
   return (
     <form className="flex items-center justify-center flex-col">
       <input
@@ -8,14 +29,29 @@ export default function EditProfileForm() {
       />
       <div className="flex w-full items-center justify-center py-6">
         <div className="w-full flex flex-col items-center justify-center gap-6">
-          <img src="" alt="" className="w-[100px] h-[100px] bg-gray-500 rounded-[50%]" />
+          <div className="relative w-[170px] h-[150px] flex items-center justify-center">
+            <img
+              src={imagePreview}
+              alt="프로필 이미지"
+              className="flex items-center justify-center w-[100px] h-[100px] bg-slate-400 rounded-[50%]"
+            />
+            <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />
+          </div>
           <label
             htmlFor={`edit-image`}
             className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white cursor-pointer"
           >
             사진변경
           </label>
-          <input type="file" id="edit-image" accept="'image/*" className="hidden" />
+          <input
+            type="file"
+            id="edit-image"
+            accept="'image/*"
+            onChange={handleImageChange}
+            ref={profileImgFileInput}
+            name="profileImgUrl"
+            className="hidden"
+          />
         </div>
       </div>
       <div className="w-full flex items-center justify-center gap-5 border-b">

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -16,7 +16,6 @@ export default function EditProfileForm() {
       setImageFiles(file);
       setImagePreview(productImgUrl);
       console.log('productImgUrl', productImgUrl);
-      console.log(``);
     }
   };
 
@@ -29,10 +28,10 @@ export default function EditProfileForm() {
       />
       <div className="flex w-full items-center justify-center py-6">
         <div className="w-full flex flex-col items-center justify-center gap-6">
-          <div className="relative w-[170px] h-[150px] flex items-center justify-center">
+          <div className="relative w-[100px] h-[100px] flex items-center justify-center">
             <img
               src={imagePreview}
-              alt="프로필 이미지"
+              alt=""
               className="flex items-center justify-center w-[100px] h-[100px] bg-slate-400 rounded-[50%]"
             />
             <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -146,7 +146,7 @@ export default function EditProfileForm() {
                 defaultValue={pf.nickname}
                 name={nickname}
                 onChange={handleNicknameChange}
-                className="outline-none py-4 "
+                className="w-[250px] outline-none py-4 "
               />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
@@ -156,7 +156,7 @@ export default function EditProfileForm() {
                 placeholder="비밀번호 입력"
                 minLength={8}
                 maxLength={16}
-                className="outline-none"
+                className="w-[250px] outline-none"
               />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
@@ -166,7 +166,7 @@ export default function EditProfileForm() {
                 placeholder="비밀번호 확인"
                 minLength={8}
                 maxLength={16}
-                className="outline-none"
+                className="w-[250px] outline-none"
               />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
@@ -177,7 +177,7 @@ export default function EditProfileForm() {
                 defaultValue={pf.location}
                 name={location}
                 onChange={handleLocationChange}
-                className="outline-none"
+                className="w-[250px] outline-none"
               />
             </div>
             <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
@@ -189,7 +189,7 @@ export default function EditProfileForm() {
                 name={phoneNumber}
                 onChange={handlePhoneNumberChange}
                 maxLength={11}
-                className="outline-none"
+                className="w-[250px] outline-none"
               />
             </div>
           </div>

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -1,7 +1,19 @@
-import { useRef, useState } from 'react';
+import { getEditProfiles } from '@/apis/myPage/profiles';
+import { EditProfile } from '@/mocks/handlers/myPage/profile';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 import { MdAddAPhoto } from 'react-icons/md';
 
 export default function EditProfileForm() {
+  const [profiles, setProfiles] = useState<EditProfile[]>([]);
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['profiles/update'],
+    queryFn: () => {
+      return getEditProfiles();
+    },
+  });
+
   const profileImgFileInput = useRef(null);
   const [imageFile, setImageFiles] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState('');
@@ -19,6 +31,21 @@ export default function EditProfileForm() {
     }
   };
 
+  useEffect(() => {
+    const fetchProfiles = async () => {
+      try {
+        const response = await getEditProfiles();
+        setProfiles(response.data);
+      } catch (error) {
+        console.error('Error fetching profiles: ', error);
+      }
+    };
+    fetchProfiles();
+  }, []);
+
+  if (isLoading) return <div>프로필 정보를 가져오는 중입니다.</div>;
+  if (error) return <div>프로필 정보를 가져오는데 실패하였습니다.</div>;
+
   return (
     <form className="flex items-center justify-center flex-col">
       <input
@@ -26,53 +53,69 @@ export default function EditProfileForm() {
         value={'완료'}
         className="absolute right-0 top-0 py-0.5 px-3 bg-primary rounded-md text-white my-[15px] mr-5"
       />
-      <div className="flex w-full items-center justify-center py-6">
-        <div className="w-full flex flex-col items-center justify-center gap-6">
-          <div className="relative w-[100px] h-[100px] flex items-center justify-center">
-            <img
-              src={imagePreview}
-              alt=""
-              className="flex items-center justify-center w-[100px] h-[100px] bg-slate-400 rounded-[50%]"
-            />
-            <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />
+      {data &&
+        data?.editProfile?.map((pf: EditProfile) => (
+          <div key={pf.id}>
+            <div className="flex w-full items-center justify-center py-6">
+              <div className="w-full flex flex-col items-center justify-center gap-6">
+                <div className="relative w-[100px] h-[100px] flex items-center justify-center">
+                  {pf.profileImgUrl ? (
+                    <img
+                      src={pf.profileImgUrl}
+                      alt="프로필 이미지"
+                      className="flex items-center justify-center w-[100px] h-[100px] border rounded-[50%]"
+                    />
+                  ) : (
+                    <>
+                      <img
+                        src={imagePreview}
+                        alt=""
+                        className="flex items-center justify-center w-[100px] h-[100px] bg-slate-400 rounded-[50%]"
+                      />
+                      <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />
+                    </>
+                  )}
+                </div>
+                <label
+                  htmlFor={`edit-image`}
+                  className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white cursor-pointer"
+                >
+                  사진변경
+                </label>
+                <input
+                  type="file"
+                  id="edit-image"
+                  accept="'image/*"
+                  onChange={handleImageChange}
+                  ref={profileImgFileInput}
+                  name="profileImgUrl"
+                  className="hidden"
+                />
+              </div>
+            </div>
+            <div className="w-full flex items-center justify-center gap-5 border-b">
+              <p className="w-[100px] font-bold">닉네임</p>
+              <input type="text" placeholder="닉네임" value={pf.nickname} className="outline-none py-4 " />
+            </div>
+            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+              <p className="w-[100px] font-bold">비밀번호</p>
+              <input type="password" placeholder="비밀번호 입력" className="outline-none" />
+            </div>
+            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+              <p className="w-[100px] font-bold">비밀번호 확인</p>
+              <input type="password" placeholder="비밀번호 확인" className="outline-none" />
+            </div>
+            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+              <p className="w-[100px] font-bold">주소</p>
+              <input type="text" placeholder="주소" value={pf.location} className="outline-none" />
+            </div>
+            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+              <p className="w-[100px] font-bold">전화번호</p>
+              <input type="text" placeholder="전화번호 입력" value={pf.phoneNumber} className="outline-none" />
+            </div>
           </div>
-          <label
-            htmlFor={`edit-image`}
-            className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 bg-primary rounded-md text-white cursor-pointer"
-          >
-            사진변경
-          </label>
-          <input
-            type="file"
-            id="edit-image"
-            accept="'image/*"
-            onChange={handleImageChange}
-            ref={profileImgFileInput}
-            name="profileImgUrl"
-            className="hidden"
-          />
-        </div>
-      </div>
-      <div className="w-full flex items-center justify-center gap-5 border-b">
-        <p className="w-[100px] font-bold">닉네임</p>
-        <input type="text" placeholder="닉네임" className="outline-none py-4 " />
-      </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px] font-bold">비밀번호</p>
-        <input type="text" placeholder="비밀번호 입력" className="outline-none" />
-      </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px] font-bold">비밀번호 확인</p>
-        <input type="text" placeholder="비밀번호 확인" className="outline-none" />
-      </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px] font-bold">주소</p>
-        <input type="text" placeholder="주소" className="outline-none" />
-      </div>
-      <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
-        <p className="w-[100px] font-bold">전화번호</p>
-        <input type="text" placeholder="전화번호 입력" className="outline-none" />
-      </div>
+        ))}
+
       <button className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 rounded-md text-white mt-28 bg-[#F94A3F]">
         회원탈퇴
       </button>

--- a/src/components/profilePage/EditProfileForm.tsx
+++ b/src/components/profilePage/EditProfileForm.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { MdAddAPhoto } from 'react-icons/md';
+import DaumPost from './DaumPost';
 
 export default function EditProfileForm() {
   const profileImgFileInput = useRef(null);
@@ -37,8 +38,9 @@ export default function EditProfileForm() {
     setNickname(e.target.value);
   };
 
-  const handleLocationChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setLocation(e.target.value);
+  // 주소 변경
+  const handleAddressChange = (address: string) => {
+    setLocation(address);
   };
 
   const handlePhoneNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -138,7 +140,7 @@ export default function EditProfileForm() {
                 />
               </div>
             </div>
-            <div className="w-full flex items-center justify-center gap-5 border-b">
+            <div className="w-full flex items-center gap-5 border-b">
               <p className="w-[100px] font-bold">닉네임</p>
               <input
                 type="text"
@@ -149,7 +151,7 @@ export default function EditProfileForm() {
                 className="w-[250px] outline-none py-4 "
               />
             </div>
-            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+            <div className="w-full flex items-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">비밀번호</p>
               <input
                 type="password"
@@ -159,7 +161,7 @@ export default function EditProfileForm() {
                 className="w-[250px] outline-none"
               />
             </div>
-            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+            <div className="w-full flex items-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">비밀번호 확인</p>
               <input
                 type="password"
@@ -169,18 +171,11 @@ export default function EditProfileForm() {
                 className="w-[250px] outline-none"
               />
             </div>
-            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+            <div className="w-full flex items-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">주소</p>
-              <input
-                type="text"
-                placeholder="주소"
-                defaultValue={pf.location}
-                name={location}
-                onChange={handleLocationChange}
-                className="w-[250px] outline-none"
-              />
+              <DaumPost onAddressChange={handleAddressChange} />
             </div>
-            <div className="w-full flex items-center justify-center py-4 gap-5 border-b text-black">
+            <div className="w-full flex items-center py-4 gap-5 border-b text-black">
               <p className="w-[100px] font-bold">전화번호</p>
               <input
                 type="text"
@@ -194,7 +189,6 @@ export default function EditProfileForm() {
             </div>
           </div>
         ))}
-
       <button className="w-[80px] h-8 flex items-center justify-center py-0.5 px-3 rounded-md text-white mt-28 bg-[#F94A3F]">
         회원탈퇴
       </button>

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,10 @@
 import { deleteBookmarkHandler, getBookmarksHandler, postBookmarkHandler } from './myPage/bookmark';
-import { getProfilesHandler, postProfilesHandler } from './myPage/profile';
+import {
+  getEditProfilesHandler,
+  getProfilesHandler,
+  postEditProfilesHandler,
+  postProfilesHandler,
+} from './myPage/profile';
 import { getAllPostsHandler, getPostByParamHandler } from './post/postHandlers';
 
 export const handlers = [
@@ -10,4 +15,6 @@ export const handlers = [
   deleteBookmarkHandler,
   getProfilesHandler,
   postProfilesHandler,
+  getEditProfilesHandler,
+  postEditProfilesHandler,
 ];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,5 +1,5 @@
 import { deleteBookmarkHandler, getBookmarksHandler, postBookmarkHandler } from './myPage/bookmark';
-import { getProfiles, postProfile } from './myPage/profile';
+import { getProfilesHandler, postProfilesHandler } from './myPage/profile';
 import { getAllPostsHandler, getPostByParamHandler } from './post/postHandlers';
 
 export const handlers = [
@@ -8,6 +8,6 @@ export const handlers = [
   getBookmarksHandler,
   postBookmarkHandler,
   deleteBookmarkHandler,
-  getProfiles,
-  postProfile,
+  getProfilesHandler,
+  postProfilesHandler,
 ];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,4 +1,5 @@
 import { getBookmarks, postBookmark } from './myPage/bookmark';
+import { getProfiles, postProfile } from './myPage/profile';
 import { getAllPosts, getPostByParam } from './post/postHandlers';
 
-export const handlers = [getAllPosts, getPostByParam, getBookmarks, postBookmark];
+export const handlers = [getAllPosts, getPostByParam, getBookmarks, postBookmark, getProfiles, postProfile];

--- a/src/mocks/handlers/myPage/profile.ts
+++ b/src/mocks/handlers/myPage/profile.ts
@@ -1,4 +1,4 @@
-import { profile } from '@/mocks/mockData/mypage/profile';
+import { editProfile, profile } from '@/mocks/mockData/mypage/profile';
 import { http, HttpResponse } from 'msw';
 
 export type Profile = {
@@ -8,10 +8,28 @@ export type Profile = {
   manners: number;
 };
 
-export const postProfilesHandler = http.post('/post/:postId/profiles', async () => {
-  return new HttpResponse(null, { status: 201 });
+export const postProfilesHandler = http.post('/users/:userId/profiles', async () => {
+  return new HttpResponse(null, { status: 200 });
 });
 
 export const getProfilesHandler = http.get('/users/profiles', () => {
   return HttpResponse.json(profile);
+});
+
+export type EditProfile = {
+  id: number;
+  nickname: string;
+  profileImgUrl: string;
+  password: null;
+  confirmPassword: null;
+  location: string;
+  phoneNumber: string;
+};
+
+export const postEditProfilesHandler = http.post('/users/:userId/profiles/update', async () => {
+  return new HttpResponse(null, { status: 200 });
+});
+
+export const getEditProfilesHandler = http.get('/users/profiles/update', async () => {
+  return HttpResponse.json(editProfile);
 });

--- a/src/mocks/handlers/myPage/profile.ts
+++ b/src/mocks/handlers/myPage/profile.ts
@@ -1,15 +1,5 @@
+import { profile } from '@/mocks/mockData/mypage/profile';
 import { http, HttpResponse } from 'msw';
-
-export const profile: { profile: Profile[] } = {
-  profile: [
-    {
-      id: 1,
-      nickname: '또담',
-      profileImgUrl: '',
-      manners: 80,
-    },
-  ],
-};
 
 export type Profile = {
   id: number;
@@ -18,10 +8,10 @@ export type Profile = {
   manners: number;
 };
 
-export const postProfile = http.post('/post/:postId', async () => {
+export const postProfilesHandler = http.post('/post/:postId/profiles', async () => {
   return new HttpResponse(null, { status: 201 });
 });
 
-export const getProfiles = http.get('/users/profiles', () => {
+export const getProfilesHandler = http.get('/users/profiles', () => {
   return HttpResponse.json(profile);
 });

--- a/src/mocks/handlers/myPage/profile.ts
+++ b/src/mocks/handlers/myPage/profile.ts
@@ -1,0 +1,27 @@
+import { http, HttpResponse } from 'msw';
+
+export const profile: { profile: Profile[] } = {
+  profile: [
+    {
+      id: 1,
+      nickname: '또담',
+      profileImgUrl: '',
+      manners: 80,
+    },
+  ],
+};
+
+export type Profile = {
+  id: number;
+  nickname: string;
+  profileImgUrl: string;
+  manners: number;
+};
+
+export const postProfile = http.post('/post/:postId', async () => {
+  return new HttpResponse(null, { status: 201 });
+});
+
+export const getProfiles = http.get('/users/profiles', () => {
+  return HttpResponse.json(profile);
+});

--- a/src/mocks/mockData/mypage/profile.ts
+++ b/src/mocks/mockData/mypage/profile.ts
@@ -1,0 +1,12 @@
+import { Profile } from '@/mocks/handlers/myPage/profile';
+
+export const profile: { profile: Profile[] } = {
+  profile: [
+    {
+      id: 1,
+      nickname: '또담',
+      profileImgUrl: '',
+      manners: 80,
+    },
+  ],
+};

--- a/src/mocks/mockData/mypage/profile.ts
+++ b/src/mocks/mockData/mypage/profile.ts
@@ -1,4 +1,4 @@
-import { Profile } from '@/mocks/handlers/myPage/profile';
+import { EditProfile, Profile } from '@/mocks/handlers/myPage/profile';
 
 export const profile: { profile: Profile[] } = {
   profile: [
@@ -7,6 +7,20 @@ export const profile: { profile: Profile[] } = {
       nickname: '또담',
       profileImgUrl: '',
       manners: 80,
+    },
+  ],
+};
+
+export const editProfile: { editProfile: EditProfile[] } = {
+  editProfile: [
+    {
+      id: 1,
+      nickname: '또담',
+      profileImgUrl: '',
+      password: null,
+      confirmPassword: null,
+      location: '서울특별시 중구 세종대로 15',
+      phoneNumber: '01012341234',
     },
   ],
 };

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -26,7 +26,7 @@ export default function ProfilePage() {
       }
     };
     fetchProfiles();
-  }, [profiles]);
+  }, []);
 
   if (isLoading) return <div>프로필 정보를 가져오는 중입니다.</div>;
   if (error) return <div>프로필 정보를 가져오는데 실패하였습니다.</div>;
@@ -47,12 +47,14 @@ export default function ProfilePage() {
                   />
                 ) : (
                   <div className="relative w-[170px] h-[150px] flex items-center justify-center">
-                    <img
-                      src={pf.profileImgUrl}
-                      alt=""
-                      className="flex items-center justify-center w-36 h-36 bg-slate-400 rounded-[50%]"
-                    />
-                    <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />
+                    <Link to="/my/edit/Profile">
+                      <img
+                        src={pf.profileImgUrl}
+                        alt=""
+                        className="flex items-center justify-center w-36 h-36 bg-slate-400 rounded-[50%]"
+                      />
+                      <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />
+                    </Link>
                   </div>
                 )}
               </div>

--- a/src/pages/MyProfilePage.tsx
+++ b/src/pages/MyProfilePage.tsx
@@ -1,19 +1,71 @@
+import { getProfiles } from '@/apis/myPage/profiles';
+import { Profile } from '@/mocks/handlers/myPage/profile';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { MdAddAPhoto } from 'react-icons/md';
 import { Link } from 'react-router-dom';
 
+// profileImgUrl
 export default function ProfilePage() {
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['profiles'],
+    queryFn: () => {
+      return getProfiles();
+    },
+  });
+
+  useEffect(() => {
+    const fetchProfiles = async () => {
+      try {
+        const response = await getProfiles();
+        setProfiles(response.data);
+      } catch (error) {
+        console.error('Error fetching profiles: ', error);
+      }
+    };
+    fetchProfiles();
+  }, [profiles]);
+
+  if (isLoading) return <div>프로필 정보를 가져오는 중입니다.</div>;
+  if (error) return <div>프로필 정보를 가져오는데 실패하였습니다.</div>;
+
   return (
     <section className="flex justify-center items-center flex-col mt-8">
       <h1 className="font-bold text-3xl">프로필</h1>
       <div className="flex items-center flex-col mt-10">
-        <div className="w-36 h-36 bg-gray-500 rounded-[50%]"></div>
-        <div className="flex items-center justify-between mt-8 gap-10">
-          <p className="py-0.5 px-3 border rounded-md text-lg">닉네임</p>
-          <p>유저 닉네임</p>
-        </div>
-        <div className="flex items-center justify-between mt-8 gap-10">
-          <p className="py-0.5 px-3 border rounded-md text-lg">매너점수</p>
-          <span>*****</span>
-        </div>
+        {data &&
+          data?.profile?.map((pf: Profile) => (
+            <div key={pf.id}>
+              <div className="relative w-[170px] h-[150px] flex items-center justify-center">
+                {pf.profileImgUrl ? (
+                  <img
+                    src={pf.profileImgUrl}
+                    alt="프로필이미지"
+                    className="flex items-center justify-center w-36 h-36 border rounded-[50%]"
+                  />
+                ) : (
+                  <div className="relative w-[170px] h-[150px] flex items-center justify-center">
+                    <img
+                      src={pf.profileImgUrl}
+                      alt=""
+                      className="flex items-center justify-center w-36 h-36 bg-slate-400 rounded-[50%]"
+                    />
+                    <MdAddAPhoto className=" absolute left-2/4 top-2/4 translate-x-[-50%] translate-y-[-50%] w-12 h-12 text-white" />
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center justify-between mt-8 gap-10">
+                <p className="py-0.5 px-3 border rounded-md text-lg">닉네임</p>
+                <p>{pf.nickname}</p>
+              </div>
+              <div className="flex items-center justify-between mt-8 gap-10">
+                <p className="py-0.5 px-3 border rounded-md text-lg">매너점수</p>
+                <span>{pf.manners}점</span>
+              </div>
+            </div>
+          ))}
         <div className="flex items-center justify-center flex-col mt-8">
           <Link to="/my/edit/Profile" className="py-0.5 px-3 bg-primary rounded-md text-white">
             수정하기

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,4 +1,4 @@
-import { CATEGORIES, SORT_OPTIONS, STATUS } from './data';
+import { CATEGORIES, SORT_OPTIONS, STATUS } from '@/lib/data';
 
 export type Category = (typeof CATEGORIES)[number]['type'];
 export type StatusFilter = (typeof STATUS)[number]['type'];


### PR DESCRIPTION
## 연관 이슈
#42 

### 요약

- Feat: 프로필 페이지

### 타입

- [x] feat : 새로운 기능 추가, 기존의 기능을 요구 사항에 맞추어 수정
- [ ] fix : 기능에 대한 버그, 오류 수정
- [ ] add : feat 이외의 부수적인 코드 추가, 라이브러리 추가
- [ ] build : 빌드 관련 수정
- [ ] chore : 프로덕션 코드 외 빌드 부분 혹은 패키지 매니저 수정사항 (ex. .gitignore)
- [x] design : css 및 레이아웃 작업
- [ ] docs : 문서,주석 수정
- [ ] style : 코드 스타일, 포맷팅에 대한 수정
- [ ] refactor : 기능의 변화가 아닌 코드 리팩터링 (ex. 변수 이름 변경)
- [ ] test : 테스트 코드 추가/수정

### 작업 내용

- UI
- 사진 등록 및 수정
- api 연결
- get, post 요청

### 스크린샷(선택)
- 프로필 페이지
![프로필 화면](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/27b361b8-e578-4090-8bee-da340161eade)

- 프로필 수정 페이지 
![첫 화면](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/811a4bb0-2113-4aef-be12-2382ba13e608)

- 프로필 수정 페이지 정보 입력
![정보입력 화면](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/d23d5cd1-2952-4587-9a52-af08886df2da)

- 프로필 수정 완료 버튼 클릭시 화면
![완료버튼 클릭 시 화면](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/12f5bc68-350d-453f-a4da-0f370fc94e8d)

### 논의하고 싶은 부분

> 프로필 이미지 위에 아이콘을 생성해두었는데 프로필 이미지가 이미 있을 시에는 아이콘을 없앨지, 아니면 그냥 저대로 진행할지 논의해보고싶습니다.

> 아직 비밀번호 확인, 회원탈퇴 기능은 구현하지 않은 상태입니다.
비밀번호 확인은 곧 구현할 예정이고 회원탈퇴 기능은 로그인 파트 마무리되는대로 진행할 예정입니다.

> 주소의 경우 버튼을 추가하는 것이 좋을까요?