### PR TITLE
Feat: 메인페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2009,45 +2009,6 @@
         "darwin"
       ]
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.16.4.tgz",
-      "integrity": "sha512-GkhjAaQ8oUTOKE4g4gsZ0u8K/IHU1+2WQSgS1TwTcYvL+sjbaQjNHFXbOJ6kgqGHIO1DfUhI/Sphi9GkRT9K+Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.16.4.tgz",
-      "integrity": "sha512-Bvm6D+NPbGMQOcxvS1zUl8H7DWlywSXsphAeOnVeiZLQ+0J6Is8T7SrjGTH29KtYkiY9vld8ZnpV3G2EPbom+w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.16.4.tgz",
-      "integrity": "sha512-i5d64MlnYBO9EkCOGe5vPR/EeDwjnKOGGdd7zKFhU5y8haKhQZTN2DgVtpODDMxUr4t2K90wTUJg7ilgND6bXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.16.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.16.4.tgz",

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,42 +8,42 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.2.14';
-const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423';
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.2.14'
+const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
 self.addEventListener('install', function () {
-  self.skipWaiting();
-});
+  self.skipWaiting()
+})
 
 self.addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim());
-});
+  event.waitUntil(self.clients.claim())
+})
 
 self.addEventListener('message', async function (event) {
-  const clientId = event.source.id;
+  const clientId = event.source.id
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
         type: 'KEEPALIVE_RESPONSE',
-      });
-      break;
+      })
+      break
     }
 
     case 'INTEGRITY_CHECK_REQUEST': {
@@ -53,78 +53,78 @@ self.addEventListener('message', async function (event) {
           packageVersion: PACKAGE_VERSION,
           checksum: INTEGRITY_CHECKSUM,
         },
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId);
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
         payload: true,
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId);
-      break;
+      activeClientIds.delete(clientId)
+      break
     }
 
     case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId);
+      activeClientIds.delete(clientId)
 
-      const remainingClients = allClients.filter(client => {
-        return client.id !== clientId;
-      });
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
 self.addEventListener('fetch', function (event) {
-  const { request } = event;
+  const { request } = event
 
   // Bypass navigation requests.
   if (request.mode === 'navigate') {
-    return;
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
   if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
-    return;
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been deleted (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
   // Generate unique request ID.
-  const requestId = crypto.randomUUID();
-  event.respondWith(handleRequest(event, requestId));
-});
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
 
 async function handleRequest(event, requestId) {
-  const client = await resolveMainClient(event);
-  const response = await getResponse(event, client, requestId);
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    (async function () {
-      const responseClone = response.clone();
+    ;(async function () {
+      const responseClone = response.clone()
 
       sendToClient(
         client,
@@ -141,11 +141,11 @@ async function handleRequest(event, requestId) {
           },
         },
         [responseClone.body],
-      );
-    })();
+      )
+    })()
   }
 
-  return response;
+  return response
 }
 
 // Resolve the main client for the given event.
@@ -153,49 +153,49 @@ async function handleRequest(event, requestId) {
 // that registered the worker. It's with the latter the worker should
 // communicate with during the response resolving phase.
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
   if (client?.frameType === 'top-level') {
-    return client;
+    return client
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   return allClients
-    .filter(client => {
+    .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible';
+      return client.visibilityState === 'visible'
     })
-    .find(client => {
+    .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 async function getResponse(event, client, requestId) {
-  const { request } = event;
+  const { request } = event
 
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = request.clone();
+  const requestClone = request.clone()
 
   function passthrough() {
-    const headers = Object.fromEntries(requestClone.headers.entries());
+    const headers = Object.fromEntries(requestClone.headers.entries())
 
     // Remove internal MSW request header so the passthrough request
     // complies with any potential CORS preflight checks on the server.
     // Some servers forbid unknown request headers.
-    delete headers['x-msw-intention'];
+    delete headers['x-msw-intention']
 
-    return fetch(requestClone, { headers });
+    return fetch(requestClone, { headers })
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -203,11 +203,11 @@ async function getResponse(event, client, requestId) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough();
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.
-  const requestBuffer = await request.arrayBuffer();
+  const requestBuffer = await request.arrayBuffer()
   const clientMessage = await sendToClient(
     client,
     {
@@ -230,35 +230,38 @@ async function getResponse(event, client, requestId) {
       },
     },
     [requestBuffer],
-  );
+  )
 
   switch (clientMessage.type) {
     case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data);
+      return respondWithMock(clientMessage.data)
     }
 
     case 'PASSTHROUGH': {
-      return passthrough();
+      return passthrough()
     }
   }
 
-  return passthrough();
+  return passthrough()
 }
 
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
-    channel.port1.onmessage = event => {
+    channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
-    client.postMessage(message, [channel.port2].concat(transferrables.filter(Boolean)));
-  });
+    client.postMessage(
+      message,
+      [channel.port2].concat(transferrables.filter(Boolean)),
+    )
+  })
 }
 
 async function respondWithMock(response) {
@@ -267,15 +270,15 @@ async function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error();
+    return Response.error()
   }
 
-  const mockedResponse = new Response(response.body, response);
+  const mockedResponse = new Response(response.body, response)
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
     enumerable: true,
-  });
+  })
 
-  return mockedResponse;
+  return mockedResponse
 }

--- a/src/components/homePage/BookmarkBtn.tsx
+++ b/src/components/homePage/BookmarkBtn.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils';
+import { BookmarkFilledIcon } from '@radix-ui/react-icons';
+
+type BookmarkBtnProps = {
+  bookmarkId: boolean;
+  isBookmarked: boolean;
+};
+
+export default function BookmarkBtn({ isBookmarked }: BookmarkBtnProps) {
+  return (
+    <button className="absolute top-[-5px] right-[5px]">
+      <BookmarkFilledIcon
+        className={cn('h-[40px] w-auto ', { 'text-slate-200': !isBookmarked }, { 'text-yellow-400': !!isBookmarked })}
+      />
+    </button>
+  );
+}

--- a/src/map/Map.tsx
+++ b/src/map/Map.tsx
@@ -16,7 +16,7 @@ export default function Map(props: MapProps) {
       return;
     }
 
-    const targetPoint = new kakao.maps.LatLng(33.450701, 126.570667);
+    const targetPoint = new kakao.maps.LatLng(37.555573, 126.924748);
     const options = {
       center: targetPoint,
       level: 3,
@@ -26,7 +26,6 @@ export default function Map(props: MapProps) {
   }, []);
 
   return (
-    // <div className="absolute left-[-50%] top-0 translate-x-2/4 w-full h-full border">
     <div className="relative mx-auto w-full h-3/4">
       <div className="static w-full h-full" ref={kakaoMapRef} />
       {map ? (

--- a/src/map/MapMarker.tsx
+++ b/src/map/MapMarker.tsx
@@ -2,10 +2,10 @@ import ReactDOM from 'react-dom';
 import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 
 import { useMap } from './useMap';
-import { IoBookmarkSharp } from 'react-icons/io5';
 import { PlaceType } from '@/types/map';
 import Badge from '@/components/atoms/Badge';
 import { PostMap } from '@/types/post';
+import BookmarkBtn from '@/components/homePage/BookmarkBtn';
 
 interface MapMarkerProps {
   place: PlaceType;
@@ -70,7 +70,7 @@ export default function MapMarker(props: MapMarkerProps) {
           onClick={() => {
             infoWindow.setMap(null);
           }}
-          className="absolute bottom-[60px] left-0 ml-[-120px] flex flex-col gap-2 w-[260px] px-7 py-4 border border-black rounded-2xl bg-white"
+          className="absolute bottom-[60px] left-0 ml-[-120px] flex flex-col gap-2 w-[270px] px-7 py-4 border border-black rounded-2xl bg-white"
         >
           {props.mapPosts &&
             props.mapPosts.map(post => (
@@ -78,7 +78,7 @@ export default function MapMarker(props: MapMarkerProps) {
                 <strong>{post.postList.title}</strong>
                 <p className="text-sm">{post.postList.place}</p>
                 <Badge variant={post.postList.status}></Badge>
-                <IoBookmarkSharp className="absolute top-[-4px] right-[20px] w-8 h-9 text-yellow-300" />
+                <BookmarkBtn bookmarkId={post.postList.bookmarkId} isBookmarked={post.postList.bookmarkId} />
               </div>
             ))}
         </button>,

--- a/src/map/MapMarker.tsx
+++ b/src/map/MapMarker.tsx
@@ -4,10 +4,12 @@ import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useMap } from './useMap';
 import { IoBookmarkSharp } from 'react-icons/io5';
 import { PlaceType } from '@/types/map';
+import { PostMap } from '@/types/post';
 
 interface MapMarkerProps {
   place: PlaceType;
   showInfo?: boolean;
+  data: PostMap;
 }
 
 export default function MapMarker(props: MapMarkerProps) {
@@ -60,20 +62,21 @@ export default function MapMarker(props: MapMarkerProps) {
 
   return container.current
     ? ReactDOM.createPortal(
-        <div
+        <button
+          key={props.place.id}
           onClick={() => {
             infoWindow.setMap(null);
           }}
           className="absolute bottom-[60px] left-0 ml-[-120px] flex flex-col gap-2 w-[260px] px-7 py-4 border border-black rounded-2xl bg-white"
         >
-          <strong>게시글 제목</strong>
+          <strong>{props.data.postList.title}</strong>
           <p className="text-sm">{props.place.address}</p>
           <p className="text-sm font-bold">
             모집 상태
-            <span className="text-sm ml-1">모집중</span>
+            <span className="text-sm ml-1">{props.data.postList.status}</span>
           </p>
           <IoBookmarkSharp className="absolute top-[-4px] right-[20px] w-8 h-9 text-yellow-300" />
-        </div>,
+        </button>,
         container.current,
       )
     : null;

--- a/src/map/MapMarker.tsx
+++ b/src/map/MapMarker.tsx
@@ -4,17 +4,20 @@ import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useMap } from './useMap';
 import { IoBookmarkSharp } from 'react-icons/io5';
 import { PlaceType } from '@/types/map';
+import Badge from '@/components/atoms/Badge';
 import { PostMap } from '@/types/post';
 
 interface MapMarkerProps {
   place: PlaceType;
   showInfo?: boolean;
-  data: PostMap;
+  mapPosts: PostMap[];
 }
 
+// TODO: 게시글이 있는 주소의 마커만 생성하기
 export default function MapMarker(props: MapMarkerProps) {
   const map = useMap();
   const container = useRef(document.createElement('div'));
+  // const [mapPosts] = useState<PostMap[]>([]);
 
   const infoWindow = useMemo(() => {
     return new kakao.maps.CustomOverlay({
@@ -31,7 +34,7 @@ export default function MapMarker(props: MapMarkerProps) {
 
     kakao.maps.event.addListener(marker, 'click', function () {
       map.setCenter(props.place.position);
-      map.setLevel(4, {
+      map.setLevel(2, {
         animate: true,
       });
       infoWindow.setMap(map);
@@ -69,13 +72,15 @@ export default function MapMarker(props: MapMarkerProps) {
           }}
           className="absolute bottom-[60px] left-0 ml-[-120px] flex flex-col gap-2 w-[260px] px-7 py-4 border border-black rounded-2xl bg-white"
         >
-          <strong>{props.data.postList.title}</strong>
-          <p className="text-sm">{props.place.address}</p>
-          <p className="text-sm font-bold">
-            모집 상태
-            <span className="text-sm ml-1">{props.data.postList.status}</span>
-          </p>
-          <IoBookmarkSharp className="absolute top-[-4px] right-[20px] w-8 h-9 text-yellow-300" />
+          {props.mapPosts &&
+            props.mapPosts.map(post => (
+              <div key={post.postList.postId}>
+                <strong>{post.postList.title}</strong>
+                <p className="text-sm">{post.postList.place}</p>
+                <Badge variant={post.postList.status}></Badge>
+                <IoBookmarkSharp className="absolute top-[-4px] right-[20px] w-8 h-9 text-yellow-300" />
+              </div>
+            ))}
         </button>,
         container.current,
       )

--- a/src/map/MapMarkerController.tsx
+++ b/src/map/MapMarkerController.tsx
@@ -1,8 +1,10 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import MapMarker from './MapMarker';
 import { useMap } from './useMap';
 import { PlaceType } from '@/types/map';
+import { PostMap } from '@/types/post';
+import { axiosAccessFn } from '@/apis/apiClient';
 
 interface MapMarkerControllerProps {
   places: PlaceType[];
@@ -11,6 +13,24 @@ interface MapMarkerControllerProps {
 
 export default function MapMarkerController(props: MapMarkerControllerProps) {
   const map = useMap();
+
+  const axiosAccess = axiosAccessFn();
+  const [, setMapPosts] = useState<PostMap[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axiosAccess({
+          method: 'get',
+          url: 'post/map/list',
+        });
+        setMapPosts(response.data);
+      } catch (error) {
+        console.error('Error fetching data: ', error);
+      }
+    };
+    fetchData();
+  }, []);
 
   useEffect(() => {
     if (props.places.length < 1) {
@@ -31,7 +51,46 @@ export default function MapMarkerController(props: MapMarkerControllerProps) {
   return (
     <>
       {props.places.map(place => {
-        return <MapMarker key={place.id} place={place} showInfo={props.selectedId === place.id} />;
+        return (
+          <MapMarker
+            key={place.id}
+            place={place}
+            showInfo={props.selectedId === place.id}
+            data={{
+              postList: {
+                postId: 59,
+                status: 'IN_PROGRESS',
+                category: 'DAILY',
+                authorId: 3,
+                authorNickname: '유저3',
+                title: '물티슈와 휴지 같이 구매하실 분',
+                content: '물티슈와 휴지를 같이 삽시다!!',
+                products: [
+                  {
+                    productName: '물티슈',
+                    price: 12000,
+                    count: 10,
+                  },
+                  {
+                    productName: '휴지',
+                    price: 3000,
+                    count: 2,
+                  },
+                ],
+                createdAt: '2024-04-18T07:05:40',
+                updatedAt: '2024-04-26T16:22:11',
+                place: '서울특별시 마포구 양화로 지하188',
+                plocationX: 37.555573,
+                plocationY: 126.924748,
+                purchaseStatus: 'FAILURE',
+                bookmarkId: false,
+              },
+              loginUserLocation: '서울특별시 마포구 양화로 지하188',
+              loginUserLocationX: 37.555573,
+              loginUserLocationY: 126.924748,
+            }}
+          />
+        );
       })}
     </>
   );

--- a/src/map/MapMarkerController.tsx
+++ b/src/map/MapMarkerController.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from 'react';
 import MapMarker from './MapMarker';
 import { useMap } from './useMap';
 import { PlaceType } from '@/types/map';
-import { PostMap } from '@/types/post';
 import { axiosAccessFn } from '@/apis/apiClient';
+import { PostMap } from '@/types/post';
 
 interface MapMarkerControllerProps {
   places: PlaceType[];
@@ -15,7 +15,7 @@ export default function MapMarkerController(props: MapMarkerControllerProps) {
   const map = useMap();
 
   const axiosAccess = axiosAccessFn();
-  const [, setMapPosts] = useState<PostMap[]>([]);
+  const [mapPosts, setMapPosts] = useState<PostMap[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -51,46 +51,7 @@ export default function MapMarkerController(props: MapMarkerControllerProps) {
   return (
     <>
       {props.places.map(place => {
-        return (
-          <MapMarker
-            key={place.id}
-            place={place}
-            showInfo={props.selectedId === place.id}
-            data={{
-              postList: {
-                postId: 59,
-                status: 'IN_PROGRESS',
-                category: 'DAILY',
-                authorId: 3,
-                authorNickname: '유저3',
-                title: '물티슈와 휴지 같이 구매하실 분',
-                content: '물티슈와 휴지를 같이 삽시다!!',
-                products: [
-                  {
-                    productName: '물티슈',
-                    price: 12000,
-                    count: 10,
-                  },
-                  {
-                    productName: '휴지',
-                    price: 3000,
-                    count: 2,
-                  },
-                ],
-                createdAt: '2024-04-18T07:05:40',
-                updatedAt: '2024-04-26T16:22:11',
-                place: '서울특별시 마포구 양화로 지하188',
-                plocationX: 37.555573,
-                plocationY: 126.924748,
-                purchaseStatus: 'FAILURE',
-                bookmarkId: false,
-              },
-              loginUserLocation: '서울특별시 마포구 양화로 지하188',
-              loginUserLocationX: 37.555573,
-              loginUserLocationY: 126.924748,
-            }}
-          />
-        );
+        return <MapMarker key={place.id} place={place} showInfo={props.selectedId === place.id} mapPosts={mapPosts} />;
       })}
     </>
   );

--- a/src/map/MapSearchInput.tsx
+++ b/src/map/MapSearchInput.tsx
@@ -1,23 +1,27 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react';
 
-import { useMap } from './useMap';
+// import { useMap } from './useMap';
 import { PlaceType } from '@/types/map';
+import { PostMap } from '@/types/post';
 
 interface MapSearchInputProps {
   onUpdatePlaces: (places: PlaceType[]) => void;
   onSelect: (placeId: string) => void;
+  posts: PostMap[];
 }
 
 // 더미 데이터 만들기 전까지는 지역으로 검색 가능. 추후에 데이터 생성 후 게시글 키워드로 수정
-// 지역 검색이여서 기존 SearchInput은 그대로 두고 따로 컴포넌트 분리, 추후에 리팩토링해야 함.
+// 검색 리스트 영역 데이터 불러와서 화면에 보여주기
 export default function MapSearchInput(props: MapSearchInputProps) {
-  const map = useMap();
+  // const map = useMap();
   const [search, setSearch] = useState('');
-  const [places, setPlaces] = useState<PlaceType[]>([]);
-  const [isSearchInput, setIsSearchInput] = useState(false);
+  // const [places, setPlaces] = useState<PlaceType[]>([]);
+  // const [isSearchInput, setIsSearchInput] = useState(false);
+  const [, setPlaces] = useState<PlaceType[]>([]);
+  const [, setIsSearchInput] = useState(false);
 
   const placeService = useRef<kakao.maps.services.Places | null>(null);
-  const listRef = useRef<HTMLUListElement>(null);
+  // const listRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     if (placeService.current) {
@@ -80,17 +84,16 @@ export default function MapSearchInput(props: MapSearchInputProps) {
   };
 
   // 리스트 클릭시 위치 이동
-  const handleItemClick = (place: PlaceType) => {
-    map.setCenter(place.position);
-    map.setLevel(4);
-    props.onSelect(place.id);
+  // const handleItemClick = (place: PlaceType) => {
+  //   map.setCenter(place.position);
+  //   map.setLevel(2);
+  //   props.onSelect(place.id);
 
-    // 리스트 영역 닫힘
-    setIsSearchInput(false);
-  };
+  //   // 리스트 영역 닫힘
+  //   setIsSearchInput(false);
+  // };
 
   return (
-    // <div className="fixed top-[89px] left-0 flex flex-col min-w-[240px] w-full h-[70px] z-[99999] px-5 bg-white my-0 mx-auto">
     <div className="absolute top-0 flex flex-col min-w-[240px] w-full h-[70px] z-[99999] px-5 bg-white my-0 mx-auto">
       <form onSubmit={handleSubmit} className="sticky min-w-[240px] w-full max-w-[768px] h-11 my-0 mx-auto">
         <input
@@ -101,27 +104,27 @@ export default function MapSearchInput(props: MapSearchInputProps) {
           className="min-w-[240px] w-full max-w-[768px] h-11 border border-black rounded hover:border-primary focus:border-primary px-3 py-1 focus:outline-none text-sm search-input"
         />
       </form>
-      {isSearchInput && (
+      {/* {isSearchInput && (
         <ul
           ref={listRef}
           className="absolute top-[50px] left-[50%] translate-x-[-50%] min-w-[240px] w-full max-w-[768px] h-40 bg-white overflow-y-auto map-search-list"
         >
-          {places.map((item, index) => {
+          {props.posts.map((item, index) => {
             return (
-              <li
-                key={item.id}
+              <button
+                key={item.postList.postId}
                 onClick={() => {
                   handleItemClick(item);
                 }}
                 className="min-w-[240px] w-full max-w-[768px] h-[60px] bg-white flex flex-col border-b hover:bg-gray-100 py-0 pr-0 pl-3.5"
               >
-                <label>{`${index + 1}. ${item.title}`}</label>
-                <span>{item.address}</span>
-              </li>
+                <label>{`${index + 1}. ${item.postList.title}`}</label>
+                <span>{item.postList.place}</span>
+              </button>
             );
           })}
         </ul>
-      )}
+      )} */}
     </div>
   );
 }

--- a/src/map/MapSearchInput.tsx
+++ b/src/map/MapSearchInput.tsx
@@ -84,6 +84,9 @@ export default function MapSearchInput(props: MapSearchInputProps) {
     map.setCenter(place.position);
     map.setLevel(4);
     props.onSelect(place.id);
+
+    // 리스트 영역 닫힘
+    setIsSearchInput(false);
   };
 
   return (

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -23,6 +23,7 @@ import {
   putPurchaseStatusHandler,
   categoryPostsHandler,
   putPostEditHandler,
+  getMapPostsHandler,
 } from './post/postHandlers';
 import {
   cancelRequestHandler,
@@ -62,4 +63,5 @@ export const handlers = [
   getAllNotificationsHandler,
   deleteNotificationHandler,
   putPostEditHandler,
+  getMapPostsHandler,
 ];

--- a/src/mocks/handlers/post/postHandlers.ts
+++ b/src/mocks/handlers/post/postHandlers.ts
@@ -7,6 +7,7 @@ import { requestsMockData } from '@/mocks/mockData/post/requests';
 import { HistoryMockData } from '@/mocks/mockData/mypage/history';
 import { categoryNameKR } from '@/lib/utils';
 import { Category } from '@/types/post';
+import { mapPosts } from '@/mocks/mockData/post/mapPosts';
 
 export const getAllPostsHandler = http.get('/post/list', () => {
   return HttpResponse.json(allPosts);
@@ -84,4 +85,8 @@ export const putPostEditHandler = http.put('/post/:postId', () => {
   return HttpResponse.json({
     message: '게시글이 성공적으로 수정되었습니다.',
   });
+});
+
+export const getMapPostsHandler = http.get('/post/map/list', () => {
+  return HttpResponse.json(mapPosts);
 });

--- a/src/mocks/mockData/post/mapPosts.ts
+++ b/src/mocks/mockData/post/mapPosts.ts
@@ -1,0 +1,65 @@
+import { PostMap } from '@/types/post';
+
+export const mapPosts: PostMap[] = [
+  {
+    postList: {
+      postId: 59,
+      status: 'IN_PROGRESS',
+      category: 'DAILY',
+      authorId: 3,
+      authorNickname: '유저3',
+      title: '물티슈와 휴지 같이 구매하실 분',
+      content: '물티슈와 휴지를 같이 삽시다!!',
+      products: [
+        {
+          productName: '물티슈',
+          price: 12000,
+          count: 10,
+        },
+        {
+          productName: '휴지',
+          price: 3000,
+          count: 2,
+        },
+      ],
+      createdAt: '2024-04-18T07:05:40',
+      updatedAt: '2024-04-26T16:22:11',
+      place: '서울특별시 마포구 양화로 지하188',
+      plocationX: 37.555573,
+      plocationY: 126.924748,
+      purchaseStatus: 'FAILURE',
+      bookmarkId: false,
+    },
+    loginUserLocation: '서울특별시 마포구 양화로 지하188',
+    loginUserLocationX: 37.555573,
+    loginUserLocationY: 126.924748,
+  },
+  // {
+  //   postList: {
+  //     postId: 60,
+  //     status: 'IN_PROGRESS',
+  //     category: 'DAILY',
+  //     authorId: 4,
+  //     authorNickname: '유저4',
+  //     title: '사과 한 박스씩 사실 분 구합니다.',
+  //     content: '사과를 삽시다',
+  //     products: [
+  //       {
+  //         productName: '사과',
+  //         price: 12000,
+  //         count: 10,
+  //       },
+  //     ],
+  //     createdAt: '2024-04-18T07:05:40',
+  //     updatedAt: '2024-04-26T16:22:11',
+  //     place: '서울특별시 마포구 양화로 지하188',
+  //     plocationX: 126.977253587649,
+  //     plocationY: 37.5637650596466,
+  //     purchaseStatus: 'PREPARING',
+  //     bookmarkId: true,
+  //   },
+  //   loginUserLocation: '서울특별시 마포구 양화로 지하188',
+  //   loginUserLocationX: 126.977253587649,
+  //   loginUserLocationY: 37.5637650596466,
+  // },
+];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,6 +9,7 @@ import MapMarkerController from '../map/MapMarkerController';
 import { PlaceType } from '@/types/map';
 import { Pencil1Icon } from '@radix-ui/react-icons';
 import useRequireLogin from '@/hooks/useRequireLogin';
+import { PostMap } from '@/types/post';
 // import { IoBookmarkSharp } from 'react-icons/io5';
 
 // 상품 이름, 주소, 모집인원 데이터에 맞춰서 불러오기
@@ -16,6 +17,7 @@ export default function HomePage() {
   useRequireLogin();
   const [places, setPlaces] = useState<PlaceType[]>([]);
   const [selectedId, setSelectedId] = useState('');
+  const [mapPosts] = useState<PostMap[]>([]);
 
   return (
     <div className="relative pt-5 w-full h-screen">
@@ -29,6 +31,7 @@ export default function HomePage() {
             onSelect={placeId => {
               setSelectedId(placeId);
             }}
+            posts={mapPosts}
           />
           <Link
             to="/post/new"

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -98,3 +98,30 @@ export type PostNew = {
   postImgUrl: string;
   content: string;
 };
+
+export type PostMapResponse = {
+  list: PostMap[];
+};
+
+export type PostMap = {
+  postList: {
+    postId: number;
+    authorId: number;
+    authorNickname: string;
+    place: string;
+    plocationX: number;
+    plocationY: number;
+    category?: Exclude<Category, 'ALL'>;
+    status: Status;
+    purchaseStatus: PurchaseStatus;
+    title: string;
+    content: string;
+    products: PreviewProduct[];
+    createdAt: string;
+    updatedAt: string;
+    bookmarkId: boolean;
+  };
+  loginUserLocation: string;
+  loginUserLocationX: number;
+  loginUserLocationY: number;
+};


### PR DESCRIPTION
## 연관 이슈

#5 

### 요약

- 메인페이지

### 타입

- [x] feat : 새로운 기능 추가, 기존의 기능을 요구 사항에 맞추어 수정
- [ ] fix : 기능에 대한 버그, 오류 수정
- [ ] add : feat 이외의 부수적인 코드 추가, 라이브러리 추가
- [ ] build : 빌드 관련 수정
- [ ] chore : 프로덕션 코드 외 빌드 부분 혹은 패키지 매니저 수정사항 (ex. .gitignore)
- [ ] design : css 및 레이아웃 작업
- [ ] docs : 문서,주석 수정
- [ ] style : 코드 스타일, 포맷팅에 대한 수정
- [ ] refactor : 기능의 변화가 아닌 코드 리팩터링 (ex. 변수 이름 변경)
- [ ] test : 테스트 코드 추가/수정

### 작업 내용

- 사용자 주소 기반 게시글 목록 보여주기

### 스크린샷(선택)
- 게시글 검색시 나오는 화면
![검색 완료시 화면](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/5ef45707-8be3-4542-b87a-579ecba363a1)

- 게시글 클릭 시 나오는 화면
![게시글 클릭 시 화면](https://github.com/ttodam-ttodam/ttodam-ttodam-FE/assets/147686447/910e3d6e-aa07-4f59-9af1-ff2c762920ee)


### 논의하고 싶은 부분

> 아직 완성된 기능은 없지만 우선 작업한 부분까지만 pr올립니다..😂

> 로그인한 사용자의 주소를 기반으로 게시글 목록을 보여주기로 했는데
그 부분을 어떻게 해야할지 감이 잡히질 않아서..
우선 mockData에 있는 주소를 첫 화면에 띄워주고 
주소를 검색하면 게시글 목록이 뜨게 해두었습니다..!
주소 검색 시 장소로 검색이 되기때문에 현재는 카카오 맵 API에서 제공하고 있는 모든 장소가 뜨고있습니다..
그리하여 게시글 검색시 아래로 나오던 게시글 리스트는 안보이게 주석처리해두었습니다..!

> 해당하는 지역의 게시글만 보여주고싶은데 어떻게 하면 좋을까요..?
그리고 검색 시 게시글 리스트에는 어떻게 연결해야 저희의 게시글 목록과 주소를 띄워줄 수 있을까요..?